### PR TITLE
Fix out of bounds exception when copying UV's

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
@@ -38,11 +38,9 @@ int32 URuntimeMeshStaticMeshConverter::CopyVertexOrGetIndex(const FStaticMeshLOD
 		// Copy UV's
 		if (NumTexCoords > 0)
 		{
-			int32 TexcoordVertIdx = NewMeshData.TexCoords.Add(LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, 0), 0);
-
-			for (int32 TexIndex = 1; TexIndex < NumTexCoords; TexIndex++)
+			for (int32 TexIndex = 0; TexIndex < NumTexCoords; TexIndex++)
 			{
-				NewMeshData.TexCoords.SetTexCoord(TexcoordVertIdx, LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, TexIndex), TexIndex);
+				NewMeshData.TexCoords.Add(LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, TexIndex), TexIndex);
 			}
 		}
 		else


### PR DESCRIPTION
This code was previously causing an out of bounds exception because new elements weren't being added for each UV channel, only one element was added at the beginning.

The crash (and fix) can be reproduced with the following actor code:

Slicable.h:
```
// Fill out your copyright notice in the Description page of Project Settings.

#pragma once

#include "CoreMinimal.h"
#include "GameFramework/Actor.h"
#include "RuntimeMeshActor.h"
#include "Slicable.generated.h"

UCLASS()
class OCULUSTUTORIAL_API ASlicable : public ARuntimeMeshActor
{
	GENERATED_BODY()
	
public:	
	// Sets default values for this actor's properties
	ASlicable();

	UPROPERTY(EditAnywhere)
	UStaticMesh* StaticMesh;

	UPROPERTY(EditAnywhere)
	UMaterial* Material;

	URuntimeMeshComponent* RuntimeMesh;

protected:
	// Called when the game starts or when spawned
	virtual void BeginPlay() override;

public:	
	// Called every frame
	virtual void Tick(float DeltaTime) override;

	void OnConstruction(const FTransform& Transform) override;

};
```

Slicable.cpp
```
// Fill out your copyright notice in the Description page of Project Settings.


#include "Slicable.h"
#include "Providers/RuntimeMeshProviderStaticMesh.h"

// Sets default values
ASlicable::ASlicable()
{
 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
	PrimaryActorTick.bCanEverTick = true;
	if (Material) {
		StaticMesh->SetMaterial(0, Material);
	}
}

void ASlicable::OnConstruction(const FTransform& Transform)
{
	Super::OnConstruction(Transform);

	URuntimeMeshProviderStaticMesh* provider = NewObject<URuntimeMeshProviderStaticMesh>(this, TEXT("RMCProvider-StaticMesh"));

	if (Material && StaticMesh && provider) {
		provider->SetStaticMesh(StaticMesh);
		GetRuntimeMeshComponent()->Initialize(provider);
	}
}

// Called when the game starts or when spawned
void ASlicable::BeginPlay()
{
	Super::BeginPlay();
	
}

// Called every frame
void ASlicable::Tick(float DeltaTime)
{
	Super::Tick(DeltaTime);

}
```