### PR TITLE
Mesh update now removes the section after the proxy update has been f…

### DIFF
--- a/Source/RuntimeMeshComponent/Public/RuntimeMesh.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMesh.h
@@ -190,7 +190,7 @@ private:
 
 	void QueueForDelayedInitialize();
 	void QueueForUpdate();
-	void QueueForMeshUpdate();
+	void QueueForMeshUpdate(TUniqueFunction<void ()> InCompletionFunc = nullptr);
 	void QueueForCollisionUpdate();
 
 	void UpdateAllComponentBounds();

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshCore.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshCore.h
@@ -162,8 +162,7 @@ public:
 
 struct FRuntimeMeshMisc
 {
-	template<typename LambdaType>
-	static void DoOnGameThread(LambdaType&& InFunction)
+	static void DoOnGameThread(TUniqueFunction<void ()> InFunction)
 	{
 		if (IsInGameThread())
 		{
@@ -171,10 +170,7 @@ struct FRuntimeMeshMisc
 		}
 		else
 		{
-			FFunctionGraphTask::CreateAndDispatchWhenReady([InFunction]()
-				{
-					InFunction();
-				}, TStatId(), nullptr, ENamedThreads::GameThread);
+			FFunctionGraphTask::CreateAndDispatchWhenReady(MoveTemp(InFunction), TStatId(), nullptr, ENamedThreads::GameThread);
 		}
 	}
 };


### PR DESCRIPTION
…inished.

Previously calling `RemoveSection` on the provider manually wouldn't update the proxy, because the section was getting removed before the actual update and during the proxy update we couldn't get the correct section. This removal has been deferred until after the proxy update now.