### PR TITLE
UE5 Preview 1 Changes (Double Precision FVector)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -26,3 +26,6 @@
 
 ### UE5 Adaptation
 [EddieAtaberk](https://github.com/eddieataberk)
+### UE5 Preview 1 (LWC Double Precision) Changes
+[Darcul](https://github.com/Darcul)
+[connorjak](https://github.com/connorjak)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -29,3 +29,4 @@
 ### UE5 Preview 1 (LWC Double Precision) Changes
 [Darcul](https://github.com/Darcul)
 [connorjak](https://github.com/connorjak)
+[sfla](https://github.com/sfla)

--- a/Source/RuntimeMeshComponent/Private/Components/RuntimeMeshComponentStatic.cpp
+++ b/Source/RuntimeMeshComponent/Private/Components/RuntimeMeshComponentStatic.cpp
@@ -34,22 +34,22 @@ void URuntimeMeshComponentStatic::CreateSection_Blueprint(int32 LODIndex, int32 
 }
 
 void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, 
-	const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, 
+	const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2,
 	const TArray<FVector2D>& UV3, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
 	StaticProvider->CreateSectionFromComponents(LODIndex, SectionIndex, MaterialSlot,
 		Vertices, Triangles, Normals, UV0, UV1, UV2, UV3, VertexColors, Tangents, UpdateFrequency, bCreateCollision);
 }
 
-void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles,
-	const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FColor>& VertexColors,
-	const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
+void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot,
+	const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2,
+	const TArray<FVector2D>& UV3, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
 	StaticProvider->CreateSectionFromComponents(LODIndex, SectionIndex, MaterialSlot,
 		Vertices, Triangles, Normals, UV0, UV1, UV2, UV3, VertexColors, Tangents, UpdateFrequency, bCreateCollision);
 }
 
-void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, 
+void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles,
 	const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
 	ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
@@ -57,7 +57,7 @@ void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, in
 		Vertices, Triangles, Normals, UV0, VertexColors, Tangents, UpdateFrequency, bCreateCollision);
 }
 
-void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, 
+void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles,
 	const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
 	ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
@@ -70,16 +70,16 @@ void URuntimeMeshComponentStatic::UpdateSection_Blueprint(int32 LODIndex, int32 
 	StaticProvider->UpdateSection_Blueprint(LODIndex, SectionId, SectionData);
 }
 
-void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, 
-	const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, 
+void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles,
+	const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3,
 	const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
-{
+{	
 	StaticProvider->UpdateSectionFromComponents(LODIndex, SectionIndex,
 		Vertices, Triangles, Normals, UV0, UV1, UV2, UV3, VertexColors, Tangents);
 }
 
-void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, 
-	const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, 
+void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles,
+	const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3,
 	const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
 {
 	StaticProvider->UpdateSectionFromComponents(LODIndex, SectionIndex,

--- a/Source/RuntimeMeshComponent/Private/Components/RuntimeMeshComponentStatic.cpp
+++ b/Source/RuntimeMeshComponent/Private/Components/RuntimeMeshComponentStatic.cpp
@@ -33,6 +33,8 @@ void URuntimeMeshComponentStatic::CreateSection_Blueprint(int32 LODIndex, int32 
 	StaticProvider->CreateSection_Blueprint(LODIndex, SectionId, SectionProperties, SectionData);
 }
 
+// NOTE: For Blueprint compatibility, this function converts inputs from double precision to single precision.
+// Use single precision(FVector3f, FVector2f) versions for C++ code!
 void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, 
 	const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2,
 	const TArray<FVector2D>& UV3, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
@@ -42,23 +44,23 @@ void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, in
 }
 
 void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot,
-	const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2,
-	const TArray<FVector2D>& UV3, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
+	const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals, const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2,
+	const TArray<FVector2f>& UV3, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
 	StaticProvider->CreateSectionFromComponents(LODIndex, SectionIndex, MaterialSlot,
 		Vertices, Triangles, Normals, UV0, UV1, UV2, UV3, VertexColors, Tangents, UpdateFrequency, bCreateCollision);
 }
 
-void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles,
-	const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
+void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles,
+	const TArray<FVector3f>& Normals, const TArray<FVector2f>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
 	ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
 	StaticProvider->CreateSectionFromComponents(LODIndex, SectionIndex, MaterialSlot,
 		Vertices, Triangles, Normals, UV0, VertexColors, Tangents, UpdateFrequency, bCreateCollision);
 }
 
-void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles,
-	const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
+void URuntimeMeshComponentStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles,
+	const TArray<FVector3f>& Normals, const TArray<FVector2f>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
 	ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
 	StaticProvider->CreateSectionFromComponents(LODIndex, SectionIndex, MaterialSlot,
@@ -70,6 +72,8 @@ void URuntimeMeshComponentStatic::UpdateSection_Blueprint(int32 LODIndex, int32 
 	StaticProvider->UpdateSection_Blueprint(LODIndex, SectionId, SectionData);
 }
 
+// NOTE: For Blueprint compatibility, this function converts inputs from double precision to single precision.
+// Use single precision(FVector3f, FVector2f) versions for C++ code!
 void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles,
 	const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3,
 	const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
@@ -78,23 +82,31 @@ void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, in
 		Vertices, Triangles, Normals, UV0, UV1, UV2, UV3, VertexColors, Tangents);
 }
 
-void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles,
-	const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3,
+void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles,
+	const TArray<FVector3f>& Normals, const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3,
+	const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
+{
+	StaticProvider->UpdateSectionFromComponents(LODIndex, SectionIndex,
+		Vertices, Triangles, Normals, UV0, UV1, UV2, UV3, VertexColors, Tangents);
+}
+
+void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles,
+	const TArray<FVector3f>& Normals, const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3,
 	const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
 {
 	StaticProvider->UpdateSectionFromComponents(LODIndex, SectionIndex,
 		Vertices, Triangles, Normals, UV0, UV1, UV2, UV3, VertexColors, Tangents);
 }
 
-void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-	const TArray<FVector2D>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
+void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+	const TArray<FVector2f>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
 {
 	StaticProvider->UpdateSectionFromComponents(LODIndex, SectionIndex,
 		Vertices, Triangles, Normals, UV0, VertexColors, Tangents);
 }
 
-void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-	const TArray<FVector2D>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
+void URuntimeMeshComponentStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+	const TArray<FVector2f>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
 {
 	StaticProvider->UpdateSectionFromComponents(LODIndex, SectionIndex,
 		Vertices, Triangles, Normals, UV0, VertexColors, Tangents);

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderBox.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderBox.cpp
@@ -79,7 +79,7 @@ bool URuntimeMeshProviderBox::GetSectionMeshForLOD(int32 LODIndex, int32 Section
 	FVector TangentX, TangentY, TangentZ;
 
 
-	auto AddVertex = [&](const FVector& InPosition, const FVector& InTangentX, const FVector& InTangentZ, const FVector2D& InTexCoord)
+	auto AddVertex = [&](const FVector& InPosition, const FVector& InTangentX, const FVector& InTangentZ, const FVector2f& InTexCoord)
 	{
 		MeshData.Positions.Add(InPosition);
 		MeshData.Tangents.Add(InTangentZ, InTangentX);
@@ -92,60 +92,60 @@ bool URuntimeMeshProviderBox::GetSectionMeshForLOD(int32 LODIndex, int32 Section
 	// Pos Z
 	TangentZ = FVector(0.0f, 0.0f, 1.0f);
 	TangentX = FVector(0.0f, -1.0f, 0.0f);
-	AddVertex(BoxVerts[0], TangentX, TangentZ, FVector2D(0.0f, 0.0f));
-	AddVertex(BoxVerts[1], TangentX, TangentZ, FVector2D(0.0f, 1.0f));
-	AddVertex(BoxVerts[2], TangentX, TangentZ, FVector2D(1.0f, 1.0f));
-	AddVertex(BoxVerts[3], TangentX, TangentZ, FVector2D(1.0f, 0.0f));
+	AddVertex(BoxVerts[0], TangentX, TangentZ, FVector2f(0.0f, 0.0f));
+	AddVertex(BoxVerts[1], TangentX, TangentZ, FVector2f(0.0f, 1.0f));
+	AddVertex(BoxVerts[2], TangentX, TangentZ, FVector2f(1.0f, 1.0f));
+	AddVertex(BoxVerts[3], TangentX, TangentZ, FVector2f(1.0f, 0.0f));
 	MeshData.Triangles.AddTriangle(0, 1, 3);
 	MeshData.Triangles.AddTriangle(1, 2, 3);
 
 	// Neg X
 	TangentZ = FVector(-1.0f, 0.0f, 0.0f);
 	TangentX = FVector(0.0f, -1.0f, 0.0f);
-	AddVertex(BoxVerts[4], TangentX, TangentZ, FVector2D(0.0f, 0.0f));
-	AddVertex(BoxVerts[0], TangentX, TangentZ, FVector2D(0.0f, 1.0f));
-	AddVertex(BoxVerts[3], TangentX, TangentZ, FVector2D(1.0f, 1.0f));
-	AddVertex(BoxVerts[7], TangentX, TangentZ, FVector2D(1.0f, 0.0f));
+	AddVertex(BoxVerts[4], TangentX, TangentZ, FVector2f(0.0f, 0.0f));
+	AddVertex(BoxVerts[0], TangentX, TangentZ, FVector2f(0.0f, 1.0f));
+	AddVertex(BoxVerts[3], TangentX, TangentZ, FVector2f(1.0f, 1.0f));
+	AddVertex(BoxVerts[7], TangentX, TangentZ, FVector2f(1.0f, 0.0f));
 	MeshData.Triangles.AddTriangle(4, 5, 7);
 	MeshData.Triangles.AddTriangle(5, 6, 7);
 
 	// Pos Y
 	TangentZ = FVector(0.0f, 1.0f, 0.0f);
 	TangentX = FVector(-1.0f, 0.0f, 0.0f);
-	AddVertex(BoxVerts[5], TangentX, TangentZ, FVector2D(0.0f, 0.0f));
-	AddVertex(BoxVerts[1], TangentX, TangentZ, FVector2D(0.0f, 1.0f));
-	AddVertex(BoxVerts[0], TangentX, TangentZ, FVector2D(1.0f, 1.0f));
-	AddVertex(BoxVerts[4], TangentX, TangentZ, FVector2D(1.0f, 0.0f));
+	AddVertex(BoxVerts[5], TangentX, TangentZ, FVector2f(0.0f, 0.0f));
+	AddVertex(BoxVerts[1], TangentX, TangentZ, FVector2f(0.0f, 1.0f));
+	AddVertex(BoxVerts[0], TangentX, TangentZ, FVector2f(1.0f, 1.0f));
+	AddVertex(BoxVerts[4], TangentX, TangentZ, FVector2f(1.0f, 0.0f));
 	MeshData.Triangles.AddTriangle(8, 9, 11);
 	MeshData.Triangles.AddTriangle(9, 10, 11);
 
 	// Pos X
 	TangentZ = FVector(1.0f, 0.0f, 0.0f);
 	TangentX = FVector(0.0f, 1.0f, 0.0f);
-	AddVertex(BoxVerts[6], TangentX, TangentZ, FVector2D(0.0f, 0.0f));
-	AddVertex(BoxVerts[2], TangentX, TangentZ, FVector2D(0.0f, 1.0f));
-	AddVertex(BoxVerts[1], TangentX, TangentZ, FVector2D(1.0f, 1.0f));
-	AddVertex(BoxVerts[5], TangentX, TangentZ, FVector2D(1.0f, 0.0f));
+	AddVertex(BoxVerts[6], TangentX, TangentZ, FVector2f(0.0f, 0.0f));
+	AddVertex(BoxVerts[2], TangentX, TangentZ, FVector2f(0.0f, 1.0f));
+	AddVertex(BoxVerts[1], TangentX, TangentZ, FVector2f(1.0f, 1.0f));
+	AddVertex(BoxVerts[5], TangentX, TangentZ, FVector2f(1.0f, 0.0f));
 	MeshData.Triangles.AddTriangle(12, 13, 15);
 	MeshData.Triangles.AddTriangle(13, 14, 15);
 
 	// Neg Y
 	TangentZ = FVector(0.0f, -1.0f, 0.0f);
 	TangentX = FVector(1.0f, 0.0f, 0.0f);
-	AddVertex(BoxVerts[7], TangentX, TangentZ, FVector2D(0.0f, 0.0f));
-	AddVertex(BoxVerts[3], TangentX, TangentZ, FVector2D(0.0f, 1.0f));
-	AddVertex(BoxVerts[2], TangentX, TangentZ, FVector2D(1.0f, 1.0f));
-	AddVertex(BoxVerts[6], TangentX, TangentZ, FVector2D(1.0f, 0.0f));
+	AddVertex(BoxVerts[7], TangentX, TangentZ, FVector2f(0.0f, 0.0f));
+	AddVertex(BoxVerts[3], TangentX, TangentZ, FVector2f(0.0f, 1.0f));
+	AddVertex(BoxVerts[2], TangentX, TangentZ, FVector2f(1.0f, 1.0f));
+	AddVertex(BoxVerts[6], TangentX, TangentZ, FVector2f(1.0f, 0.0f));
 	MeshData.Triangles.AddTriangle(16, 17, 19);
 	MeshData.Triangles.AddTriangle(17, 18, 19);
 
 	// Neg Z
 	TangentZ = FVector(0.0f, 0.0f, -1.0f);
 	TangentX = FVector(0.0f, 1.0f, 0.0f);
-	AddVertex(BoxVerts[7], TangentX, TangentZ, FVector2D(0.0f, 0.0f));
-	AddVertex(BoxVerts[6], TangentX, TangentZ, FVector2D(0.0f, 1.0f));
-	AddVertex(BoxVerts[5], TangentX, TangentZ, FVector2D(1.0f, 1.0f));
-	AddVertex(BoxVerts[4], TangentX, TangentZ, FVector2D(1.0f, 0.0f));
+	AddVertex(BoxVerts[7], TangentX, TangentZ, FVector2f(0.0f, 0.0f));
+	AddVertex(BoxVerts[6], TangentX, TangentZ, FVector2f(0.0f, 1.0f));
+	AddVertex(BoxVerts[5], TangentX, TangentZ, FVector2f(1.0f, 1.0f));
+	AddVertex(BoxVerts[4], TangentX, TangentZ, FVector2f(1.0f, 0.0f));
 	MeshData.Triangles.AddTriangle(20, 21, 23);
 	MeshData.Triangles.AddTriangle(21, 22, 23);
 

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderCollision.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderCollision.cpp
@@ -163,12 +163,12 @@ bool URuntimeMeshProviderCollision::GetCollisionMesh(FRuntimeMeshCollisionData& 
 			{
 				if (ChannelId < CachedSection.TexCoords.NumChannels() && CachedSection.TexCoords.NumTexCoords(ChannelId) > Index)
 				{
-					FVector2f TexCoord = CachedSection.TexCoords.GetTexCoord(ChannelId, Index);
+					FVector2D TexCoord = CachedSection.TexCoords.GetTexCoord(ChannelId, Index);
 					CollisionData.TexCoords.SetTexCoord(ChannelId, Index, TexCoord);
 				}
 				else
 				{
-					CollisionData.TexCoords.SetTexCoord(ChannelId, Index, FVector2f::ZeroVector);
+					CollisionData.TexCoords.SetTexCoord(ChannelId, Index, FVector2D::ZeroVector);
 				}
 			}
 		}

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderCollision.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderCollision.cpp
@@ -163,12 +163,12 @@ bool URuntimeMeshProviderCollision::GetCollisionMesh(FRuntimeMeshCollisionData& 
 			{
 				if (ChannelId < CachedSection.TexCoords.NumChannels() && CachedSection.TexCoords.NumTexCoords(ChannelId) > Index)
 				{
-					FVector2D TexCoord = CachedSection.TexCoords.GetTexCoord(ChannelId, Index);
+					FVector2f TexCoord = CachedSection.TexCoords.GetTexCoord(ChannelId, Index);
 					CollisionData.TexCoords.SetTexCoord(ChannelId, Index, TexCoord);
 				}
 				else
 				{
-					CollisionData.TexCoords.SetTexCoord(ChannelId, Index, FVector2D::ZeroVector);
+					CollisionData.TexCoords.SetTexCoord(ChannelId, Index, FVector2f::ZeroVector);
 				}
 			}
 		}

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderPlane.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderPlane.cpp
@@ -63,7 +63,7 @@ bool URuntimeMeshProviderPlane::GetSectionMeshForLOD(int32 LODIndex, int32 Secti
 		for (int32 ABIndex = 0; ABIndex < NumVertsAB; ABIndex++)
 		{
 			FVector Location = LocationA + ABDirection * ABIndex + ACDirection * ACIndex;
-			FVector2D TexCoord = FVector2D((float)ABIndex / (float)(NumVertsAB - 1), (float)ACIndex / (float)(NumVertsAC - 1));
+			FVector2f TexCoord = FVector2f((float)ABIndex / (float)(NumVertsAB - 1), (float)ACIndex / (float)(NumVertsAC - 1));
 			//UE_LOG(LogTemp, Log, TEXT("TexCoord for vertex %i:%i : %s"), ABIndex, ACIndex, *TexCoord.ToString());
 			MeshData.Positions.Add(Location);
 			MeshData.Tangents.Add(Normal, Tangent);

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderSphere.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderSphere.cpp
@@ -233,8 +233,8 @@ float URuntimeMeshProviderSphere::CalculateScreenSize(int32 LODIndex)
 
 bool URuntimeMeshProviderSphere::GetSphereMesh(int32 SphereRadius, int32 LatitudeSegments, int32 LongitudeSegments, FRuntimeMeshRenderableMeshData& MeshData)
 {
-	TArray<FVector> LatitudeVerts;
-	TArray<FVector> TangentVerts;
+	TArray<FVector3f> LatitudeVerts;
+	TArray<FVector3f> TangentVerts;
 	int32 TrisOrder[6] = { 0, 1, LatitudeSegments + 1, 1, LatitudeSegments + 2, LatitudeSegments + 1 };
 	//Baked trigonometric data to avoid computing it too much (sin and cos are expensive !)
 	LatitudeVerts.SetNumUninitialized(LatitudeSegments + 1);
@@ -244,9 +244,9 @@ bool URuntimeMeshProviderSphere::GetSphereMesh(int32 SphereRadius, int32 Latitud
 		float angle = LatitudeIndex * 2.f * PI / LatitudeSegments;
 		float x, y;
 		FMath::SinCos(&y, &x, angle);
-		LatitudeVerts[LatitudeIndex] = FVector(x, y, 0);
+		LatitudeVerts[LatitudeIndex] = FVector3f(x, y, 0);
 		FMath::SinCos(&y, &x, angle + PI / 2.f);
-		TangentVerts[LatitudeIndex] = FVector(x, y, 0);
+		TangentVerts[LatitudeIndex] = FVector3f(x, y, 0);
 	}
 	//Making the verts
 	for (int32 LongitudeIndex = 0; LongitudeIndex < LongitudeSegments + 1; LongitudeIndex++) //This is one more vert than geometrically needed but this avoid having to make wrap-around code
@@ -256,11 +256,11 @@ bool URuntimeMeshProviderSphere::GetSphereMesh(int32 SphereRadius, int32 Latitud
 		FMath::SinCos(&r, &z, angle);
 		for (int32 LatitudeIndex = 0; LatitudeIndex < LatitudeSegments + 1; LatitudeIndex++) //In total, we only waste (2*LatitudeSegments + LongitudeSegments - 2) vertices but save LatitudeSegments*LongitudeSegments operations
 		{
-			FVector Normal = LatitudeVerts[LatitudeIndex] * r + FVector(0, 0, z);
-			FVector Position = Normal * SphereRadius;
+			FVector3f Normal = LatitudeVerts[LatitudeIndex] * r + FVector3f(0, 0, z);
+			FVector3f Position = Normal * SphereRadius;
 			MeshData.Positions.Add(Position);
 			MeshData.Tangents.Add(Normal, TangentVerts[LatitudeIndex]);
-			MeshData.TexCoords.Add(FVector2D((float)LatitudeIndex / LatitudeSegments, (float)LongitudeIndex / LongitudeSegments));
+			MeshData.TexCoords.Add(FVector2f((float)LatitudeIndex / LatitudeSegments, (float)LongitudeIndex / LongitudeSegments));
 			MeshData.Colors.Add(FColor::White);
 		}
 	}

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
@@ -492,7 +492,7 @@ bool URuntimeMeshProviderStatic::GetCollisionMesh(FRuntimeMeshCollisionData& Col
 							}
 							for (int32 ChannelIdx = 0; ChannelIdx < NumChannels; ChannelIdx++)
 							{
-								CollisionData.TexCoords.SetTexCoord(ChannelIdx, FirstVertex + VertIdx, SectionData.TexCoords.GetTexCoord(VertIdx, ChannelIdx));
+								CollisionData.TexCoords.SetTexCoord(ChannelIdx, FirstVertex + VertIdx, FVector2D(SectionData.TexCoords.GetTexCoord(VertIdx, ChannelIdx)));
 							}
 						}
 

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
@@ -29,8 +29,32 @@ void URuntimeMeshProviderStatic::UnRegisterModifier(URuntimeMeshModifier* Modifi
 	CurrentMeshModifiers.Remove(Modifier);
 }
 
+// NOTE: For Blueprint compatibility, this function converts inputs from double precision to single precision.
+// Use single precision(FVector3f, FVector2f) versions for C++ code!
 void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-	const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FLinearColor>& VertexColors, 
+	const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FLinearColor>& VertexColors,
+	const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
+{
+	auto Verticesf = RMC_ConvertTArray<FVector3f>(Vertices);
+	auto Normalsf = RMC_ConvertTArray<FVector3f>(Normals);
+	auto UV0f = RMC_ConvertTArray<FVector2f>(UV0);
+	auto UV1f = RMC_ConvertTArray<FVector2f>(UV1);
+	auto UV2f = RMC_ConvertTArray<FVector2f>(UV2);
+	auto UV3f = RMC_ConvertTArray<FVector2f>(UV3);
+
+	FRuntimeMeshSectionProperties Properties;
+	Properties.MaterialSlot = MaterialSlot;
+	Properties.UpdateFrequency = UpdateFrequency;
+
+	FRuntimeMeshRenderableMeshData SectionData = FillMeshData(Properties, Verticesf, Normalsf, Tangents, VertexColors, UV0f, UV1f, UV2f, UV3f, Triangles);
+
+	CreateSection(LODIndex, SectionIndex, Properties, SectionData);
+
+	UpdateSectionAffectsCollision(LODIndex, SectionIndex, bCreateCollision, true);
+}
+
+void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+	const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FLinearColor>& VertexColors, 
 	const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
 	FRuntimeMeshSectionProperties Properties;
@@ -44,8 +68,8 @@ void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int
 	UpdateSectionAffectsCollision(LODIndex, SectionIndex, bCreateCollision, true);
 }
 
-void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-	const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FColor>& VertexColors, 
+void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+	const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FColor>& VertexColors, 
 	const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
 	FRuntimeMeshSectionProperties Properties;
@@ -59,8 +83,8 @@ void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int
 	UpdateSectionAffectsCollision(LODIndex, SectionIndex, bCreateCollision, true);
 }	
 
-void  URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-	const TArray<FVector2D>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
+void  URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+	const TArray<FVector2f>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
 	FRuntimeMeshSectionProperties Properties;
 	Properties.MaterialSlot = MaterialSlot;
@@ -73,8 +97,8 @@ void  URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, in
 	UpdateSectionAffectsCollision(LODIndex, SectionIndex, bCreateCollision, true);
 }
 
-void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-	const TArray<FVector2D>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
+void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+	const TArray<FVector2f>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
 	FRuntimeMeshSectionProperties Properties;
 	Properties.MaterialSlot = MaterialSlot;
@@ -87,17 +111,26 @@ void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int
 	UpdateSectionAffectsCollision(LODIndex, SectionIndex, bCreateCollision, true);
 }
 
+// NOTE: For Blueprint compatibility, this function converts inputs from double precision to single precision.
+// Use single precision(FVector3f, FVector2f) versions for C++ code!
 void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
 	const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
 {
+	auto Verticesf = RMC_ConvertTArray<FVector3f>(Vertices);
+	auto Normalsf = RMC_ConvertTArray<FVector3f>(Normals);
+	auto UV0f = RMC_ConvertTArray<FVector2f>(UV0);
+	auto UV1f = RMC_ConvertTArray<FVector2f>(UV1);
+	auto UV2f = RMC_ConvertTArray<FVector2f>(UV2);
+	auto UV3f = RMC_ConvertTArray<FVector2f>(UV3);
+
 	FRuntimeMeshSectionProperties Properties;
-	FRuntimeMeshRenderableMeshData SectionData = FillMeshData(Properties, Vertices, Normals, Tangents, VertexColors, UV0, UV1, UV2, UV3, Triangles);
+	FRuntimeMeshRenderableMeshData SectionData = FillMeshData(Properties, Verticesf, Normalsf, Tangents, VertexColors, UV0f, UV1f, UV2f, UV3f, Triangles);
 
 	UpdateSection(LODIndex, SectionIndex, SectionData);
 }
 
-void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-	const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
+void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+	const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
 {
 	FRuntimeMeshSectionProperties Properties;
 	FRuntimeMeshRenderableMeshData SectionData = FillMeshData(Properties, Vertices, Normals, Tangents, VertexColors, UV0, UV1, UV2, UV3, Triangles);
@@ -105,8 +138,17 @@ void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int
 	UpdateSection(LODIndex, SectionIndex, SectionData);
 }
 
-void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-	const TArray<FVector2D>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
+void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+	const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
+{
+	FRuntimeMeshSectionProperties Properties;
+	FRuntimeMeshRenderableMeshData SectionData = FillMeshData(Properties, Vertices, Normals, Tangents, VertexColors, UV0, UV1, UV2, UV3, Triangles);
+
+	UpdateSection(LODIndex, SectionIndex, SectionData);
+}
+
+void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+	const TArray<FVector2f>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
 {
 	FRuntimeMeshSectionProperties Properties;
 	FRuntimeMeshRenderableMeshData SectionData = FillMeshData(Properties, Vertices, Normals, Tangents, VertexColors, UV0, EmptyUVs, EmptyUVs, EmptyUVs, Triangles);
@@ -114,8 +156,8 @@ void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int
 	UpdateSection(LODIndex, SectionIndex, SectionData);
 }
 
-void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-	const TArray<FVector2D>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
+void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+	const TArray<FVector2f>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
 {
 	int32 NumTexChannels = 1;
 
@@ -678,7 +720,7 @@ void URuntimeMeshProviderStatic::Serialize(FArchive& Ar)
 
 
 
-const TArray<FVector2D> URuntimeMeshProviderStatic::EmptyUVs;
+const TArray<FVector2f> URuntimeMeshProviderStatic::EmptyUVs;
 
 void URuntimeMeshProviderStatic::UpdateSectionAffectsCollision(int32 LODIndex, int32 SectionId, bool bAffectsCollision, bool bForceUpdate)
 {
@@ -785,5 +827,4 @@ void URuntimeMeshProviderStatic::BeginDestroy()
 	}
 	Super::BeginDestroy();
 }
-
 #undef RMC_LOG_VERBOSE

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
@@ -29,14 +29,14 @@ void URuntimeMeshProviderStatic::UnRegisterModifier(URuntimeMeshModifier* Modifi
 	CurrentMeshModifiers.Remove(Modifier);
 }
 
-void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, 
+void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
 	const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FLinearColor>& VertexColors, 
 	const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
 	FRuntimeMeshSectionProperties Properties;
 	Properties.MaterialSlot = MaterialSlot;
 	Properties.UpdateFrequency = UpdateFrequency;
-
+	
 	FRuntimeMeshRenderableMeshData SectionData = FillMeshData(Properties, Vertices, Normals, Tangents, VertexColors, UV0, UV1, UV2, UV3, Triangles);
 
 	CreateSection(LODIndex, SectionIndex, Properties, SectionData);
@@ -44,7 +44,7 @@ void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int
 	UpdateSectionAffectsCollision(LODIndex, SectionIndex, bCreateCollision, true);
 }
 
-void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, 
+void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
 	const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FColor>& VertexColors, 
 	const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
@@ -73,7 +73,7 @@ void  URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, in
 	UpdateSectionAffectsCollision(LODIndex, SectionIndex, bCreateCollision, true);
 }
 
-void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, 
+void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
 	const TArray<FVector2D>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency, bool bCreateCollision)
 {
 	FRuntimeMeshSectionProperties Properties;
@@ -87,7 +87,7 @@ void URuntimeMeshProviderStatic::CreateSectionFromComponents(int32 LODIndex, int
 	UpdateSectionAffectsCollision(LODIndex, SectionIndex, bCreateCollision, true);
 }
 
-void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, 
+void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
 	const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
 {
 	FRuntimeMeshSectionProperties Properties;
@@ -96,7 +96,7 @@ void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int
 	UpdateSection(LODIndex, SectionIndex, SectionData);
 }
 
-void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, 
+void URuntimeMeshProviderStatic::UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
 	const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents)
 {
 	FRuntimeMeshSectionProperties Properties;

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStaticMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStaticMesh.cpp
@@ -109,7 +109,7 @@ void URuntimeMeshProviderStaticMesh::UpdateRenderingFromStaticMesh()
 	// Setup the LODs and sections
 
 	// Check valid static mesh
-	if (StaticMesh == nullptr || StaticMesh->IsPendingKill())
+	if (!IsValid(StaticMesh))
 	{
 		ConfigureLODs({ FRuntimeMeshLODProperties() });
 		MarkCollisionDirty();

--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -544,16 +544,7 @@ bool URuntimeMesh::GetPhysicsTriMeshData(struct FTriMeshCollisionData* Collision
 
 		if (MeshProviderPtr->GetCollisionMesh(CollisionMesh))
 		{
-			/*
-			CollisionData->Vertices.Empty();
-			for (FVector v : CollisionMesh.Vertices.TakeContents()) {
-				CollisionData->Vertices.Add((FVector3f)v);
-			}
-			*/
-
-			CollisionData->Vertices = TArray<FVector3f>(MoveTemp(CollisionMesh.Vertices.Data));// .TakeContents());
-
-//			CollisionData->Vertices = CollisionMesh.Vertices.TakeContents();
+			CollisionData->Vertices = RMC_ConvertTArray<FVector3f>(CollisionMesh.Vertices.TakeContents());
 			CollisionData->Indices = CollisionMesh.Triangles.TakeContents();
 			//TODO might need to implement a 2D form of RMC_ConvertTArray for performance / correctness?
 			CollisionData->UVs = RMC_ConvertTArray<TArray<FVector2D>>(CollisionMesh.TexCoords.TakeContents()); //TODO might need to implement a 2D form of RMC_ConvertTArray

--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -544,10 +544,9 @@ bool URuntimeMesh::GetPhysicsTriMeshData(struct FTriMeshCollisionData* Collision
 
 		if (MeshProviderPtr->GetCollisionMesh(CollisionMesh))
 		{
-			CollisionData->Vertices = RMC_ConvertTArray<FVector3f>(CollisionMesh.Vertices.TakeContents());
+			CollisionData->Vertices = CollisionMesh.Vertices.TakeContents();
 			CollisionData->Indices = CollisionMesh.Triangles.TakeContents();
-			//TODO might need to implement a 2D form of RMC_ConvertTArray for performance / correctness?
-			CollisionData->UVs = RMC_ConvertTArray<TArray<FVector2D>>(CollisionMesh.TexCoords.TakeContents()); //TODO might need to implement a 2D form of RMC_ConvertTArray
+			CollisionData->UVs = CollisionMesh.TexCoords.TakeContents();
 			CollisionData->MaterialIndices = CollisionMesh.MaterialIndices.TakeContents();
 
 			CollisionData->bDeformableMesh = CollisionMesh.bDeformableMesh;
@@ -950,7 +949,7 @@ void URuntimeMesh::UpdateCollision(bool bForceCookNow)
 			for (const FRuntimeMeshCollisionConvexMesh& Convex : CollisionSettings.ConvexElements)
 			{
 				FKConvexElem& NewConvexElem = *new(ConvexElems) FKConvexElem();
-				NewConvexElem.VertexData = RMC_ConvertTArray<FVector>(Convex.VertexBuffer);
+				NewConvexElem.VertexData = Convex.VertexBuffer;
 				// TODO: Store this on the section so we don't have to compute it on each cook
 				NewConvexElem.ElemBox = FBox(Convex.BoundingBox);
 			}

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshBlueprintFunctions.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshBlueprintFunctions.cpp
@@ -205,7 +205,7 @@ void URuntimeMeshBlueprintFunctions::EmptyTexCoords(FRuntimeMeshVertexTexCoordSt
 void URuntimeMeshBlueprintFunctions::AddTexCoord(FRuntimeMeshVertexTexCoordStream& Stream, FRuntimeMeshVertexTexCoordStream& OutStream, int32& OutIndex, FVector2D InTexCoord, int32 ChannelId)
 {
 	OutStream = Stream;
-	OutIndex = Stream.Add(InTexCoord, ChannelId);
+	OutIndex = Stream.Add(FVector2f(InTexCoord), ChannelId);
 }
 
 void URuntimeMeshBlueprintFunctions::AppendTexCoords(FRuntimeMeshVertexTexCoordStream& Stream, FRuntimeMeshVertexTexCoordStream& OutStream, const FRuntimeMeshVertexTexCoordStream& InOther)
@@ -217,13 +217,13 @@ void URuntimeMeshBlueprintFunctions::AppendTexCoords(FRuntimeMeshVertexTexCoordS
 void URuntimeMeshBlueprintFunctions::GetTexCoord(FRuntimeMeshVertexTexCoordStream& Stream, FRuntimeMeshVertexTexCoordStream& OutStream, int32 Index, int32 ChannelId, FVector2D& OutTexCoord)
 {
 	OutStream = Stream;
-	OutTexCoord = Stream.GetTexCoord(Index, ChannelId);
+	OutTexCoord = FVector2D(Stream.GetTexCoord(Index, ChannelId));
 }
 
 void URuntimeMeshBlueprintFunctions::SetTexCoord(FRuntimeMeshVertexTexCoordStream& Stream, FRuntimeMeshVertexTexCoordStream& OutStream, int32 Index, FVector2D NewTexCoord, int32 ChannelId /*= 0*/)
 {
 	OutStream = Stream;
-	Stream.SetTexCoord(Index, NewTexCoord, ChannelId);
+	Stream.SetTexCoord(Index, FVector2f(NewTexCoord), ChannelId);
 }
 
 
@@ -457,19 +457,19 @@ void URuntimeMeshBlueprintFunctions::EmptyCollisionTexCoords(FRuntimeMeshVertexT
 void URuntimeMeshBlueprintFunctions::AddCollisionTexCoord(FRuntimeMeshVertexTexCoordStream& Stream, FRuntimeMeshVertexTexCoordStream& OutStream, FVector2D InTexCoord, int32& OutIndex)
 {
 	OutStream = Stream;
-	OutIndex = Stream.Add(InTexCoord);
+	OutIndex = Stream.Add(FVector2f(InTexCoord));
 }
 
 void URuntimeMeshBlueprintFunctions::GetCollisionTexCoord(FRuntimeMeshVertexTexCoordStream& Stream, FRuntimeMeshVertexTexCoordStream& OutStream, int32 Index, FVector2D& OutTexCoord, int32 ChannelId)
 {
 	OutStream = Stream;
-	OutTexCoord = Stream.GetTexCoord(Index, ChannelId);
+	OutTexCoord = FVector2D(Stream.GetTexCoord(Index, ChannelId));
 }
 
 void URuntimeMeshBlueprintFunctions::SetCollisionTexCoord(FRuntimeMeshVertexTexCoordStream& Stream, FRuntimeMeshVertexTexCoordStream& OutStream, int32 Index, FVector2D NewTexCoord, int32 ChannelId /*= 0*/)
 {
 	OutStream = Stream;
-	Stream.SetTexCoord(Index, NewTexCoord, ChannelId);
+	Stream.SetTexCoord(Index, FVector2f(NewTexCoord), ChannelId);
 }
 
 

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshBlueprintFunctions.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshBlueprintFunctions.cpp
@@ -162,7 +162,11 @@ void URuntimeMeshBlueprintFunctions::SetTangent(FRuntimeMeshVertexTangentStream&
 void URuntimeMeshBlueprintFunctions::GetTangents(FRuntimeMeshVertexTangentStream& Stream, FRuntimeMeshVertexTangentStream& OutStream, int32 Index, FVector& OutTangentX, FVector& OutTangentY, FVector& OutTangentZ)
 {
 	OutStream = Stream;
-	Stream.GetTangents(Index, OutTangentX, OutTangentY, OutTangentZ);
+	FVector3f tangentX, tangentY, tangentZ;
+	Stream.GetTangents(Index, tangentX, tangentY, tangentZ);
+	OutTangentX = (FVector)tangentX;
+	OutTangentY = (FVector)tangentY;
+	OutTangentZ = (FVector)tangentZ;
 }
 
 void URuntimeMeshBlueprintFunctions::SetTangents(FRuntimeMeshVertexTangentStream& Stream, FRuntimeMeshVertexTangentStream& OutStream, int32 Index, FVector InTangentX, FVector InTangentY, FVector InTangentZ)

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
@@ -105,10 +105,10 @@ FPrimitiveViewRelevance FRuntimeMeshComponentSceneProxy::GetViewRelevance(const 
 	Result.bRenderCustomDepth = ShouldRenderCustomDepth();
 	MaterialRelevance.SetPrimitiveViewRelevance(Result);
 	Result.bTranslucentSelfShadow = bCastVolumetricTranslucentShadow;
-#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 25
-	Result.bVelocityRelevance = IsMovable() && Result.bOpaque && Result.bRenderInMainPass;
-#else
+#if ENGINE_MAJOR_VERSION <= 4 && ENGINE_MINOR_VERSION <= 24
 	Result.bVelocityRelevance = IsMovable() && Result.bOpaqueRelevance && Result.bRenderInMainPass;
+#else
+	Result.bVelocityRelevance = IsMovable() && Result.bOpaque && Result.bRenderInMainPass;
 #endif
 	return Result;
 }

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshCore.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshCore.cpp
@@ -210,7 +210,7 @@ FRuntimeMeshRenderableCollisionData::FRuntimeMeshRenderableCollisionData(const F
 	{
 		for (int32 ChannelId = 0; ChannelId < NumChannels; ChannelId++)
 		{
-			TexCoords.SetTexCoord(ChannelId, Index, InRenderable.TexCoords.GetTexCoord(Index, ChannelId));
+			TexCoords.SetTexCoord(ChannelId, Index, FVector2D(InRenderable.TexCoords.GetTexCoord(Index, ChannelId)));
 		}
 	}
 

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.h
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.h
@@ -258,7 +258,7 @@ class FRuntimeMeshPositionVertexBuffer : public FRuntimeMeshVertexBuffer
 {
 public:
 	FRuntimeMeshPositionVertexBuffer(bool bInIsDynamicBuffer)
-		: FRuntimeMeshVertexBuffer(bInIsDynamicBuffer, sizeof(FVector))
+		: FRuntimeMeshVertexBuffer(bInIsDynamicBuffer, sizeof(FVector3f))
 	{
 
 	}
@@ -279,7 +279,7 @@ public:
 	{
 		if (VertexBufferRHI && IntermediateBuffer)
 		{
-			VertexSize = sizeof(FVector);
+			VertexSize = sizeof(FVector3f);
 			NumVertices = NumElements;
 
 			FRuntimeMeshVertexBuffer::UpdateRHIFromExisting<MaxNumUpdates>(IntermediateBuffer, Batcher);
@@ -288,7 +288,7 @@ public:
 
 	void InitRHIFromExisting(const FBufferRHIRef& InVertexBufferRHI, int32 NumElements)
 	{
-		VertexSize = sizeof(FVector);
+		VertexSize = sizeof(FVector3f);
 		NumVertices = NumElements;
 
 		FRuntimeMeshVertexBuffer::InitRHIFromExisting(InVertexBufferRHI);
@@ -375,7 +375,7 @@ class FRuntimeMeshTexCoordsVertexBuffer : public FRuntimeMeshVertexBuffer
 {
 	static constexpr int32 CalculateStride(bool bShouldUseHighPrecision, int32 InNumUVs)
 	{
-		return (bShouldUseHighPrecision ? sizeof(FVector2D) : sizeof(FVector2DHalf)) * InNumUVs;
+		return (bShouldUseHighPrecision ? sizeof(FVector2f) : sizeof(FVector2DHalf)) * InNumUVs;
 	}
 
 private:
@@ -396,7 +396,7 @@ public:
 
 	virtual FString GetFriendlyName() const override { return TEXT("FRuntimeMeshUVsVertexBuffer"); }
 
-	virtual int32 GetElementDatumSize() const override { return bUseHighPrecision ? sizeof(FVector2D) : sizeof(FVector2DHalf); }
+	virtual int32 GetElementDatumSize() const override { return bUseHighPrecision ? sizeof(FVector2f) : sizeof(FVector2DHalf); }
 	virtual EPixelFormat GetElementFormat() const override { return bUseHighPrecision ? PF_G32R32F : PF_G16R16F; }
 
 	virtual void Bind(FLocalVertexFactory::FDataType& DataType) override
@@ -410,7 +410,7 @@ public:
 		uint32 UVSizeInBytes = 0;
 		if (bUseHighPrecision)
 		{
-			UVSizeInBytes = sizeof(FVector2D);
+			UVSizeInBytes = sizeof(FVector2f);
 			UVDoubleWideVertexElementType = VET_Float4;
 			UVVertexElementType = VET_Float2;
 		}

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.h
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.h
@@ -107,13 +107,13 @@ public:
 
 
 
-	FVertexBufferRHIRef PositionsBuffer;
-	FVertexBufferRHIRef TangentsBuffer;
-	FVertexBufferRHIRef TexCoordsBuffer;
-	FVertexBufferRHIRef ColorsBuffer;
+	FBufferRHIRef PositionsBuffer;
+	FBufferRHIRef TangentsBuffer;
+	FBufferRHIRef TexCoordsBuffer;
+	FBufferRHIRef ColorsBuffer;
 
-	FIndexBufferRHIRef TrianglesBuffer;
-	FIndexBufferRHIRef AdjacencyTrianglesBuffer;
+	FBufferRHIRef TrianglesBuffer;
+	FBufferRHIRef AdjacencyTrianglesBuffer;
 
 
 	const bool bHighPrecisionTangents : 1;
@@ -200,23 +200,23 @@ public:
 public:
 
 	template<bool bIsInRenderThread>
-	static FVertexBufferRHIRef CreateRHIBuffer(FRHIResourceCreateInfo& CreateInfo, uint32 SizeInBytes, bool bDynamicBuffer)
+	static FBufferRHIRef CreateRHIBuffer(FRHIResourceCreateInfo& CreateInfo, uint32 SizeInBytes, bool bDynamicBuffer)
 	{
-		const int32 Flags = (bDynamicBuffer ? BUF_Dynamic : BUF_Static) | BUF_ShaderResource;
+//		const int32 Flags = (bDynamicBuffer ? BUF_Dynamic : BUF_Static) | BUF_ShaderResource;
 		CreateInfo.bWithoutNativeResource = SizeInBytes <= 0;
 		if (bIsInRenderThread)
 		{
-			return RHICreateVertexBuffer(SizeInBytes, Flags, CreateInfo);
+			return RHICreateVertexBuffer(SizeInBytes, (bDynamicBuffer ? BUF_Dynamic : BUF_Static) | BUF_ShaderResource, CreateInfo);
 		}
 		else
 		{
-			return RHIAsyncCreateVertexBuffer(SizeInBytes, Flags, CreateInfo);
+			return RHIAsyncCreateVertexBuffer(SizeInBytes, (bDynamicBuffer ? BUF_Dynamic : BUF_Static) | BUF_ShaderResource, CreateInfo);
 		}
 		return nullptr;
 	}
 
 	template<bool bIsInRenderThread>
-	static FVertexBufferRHIRef CreateRHIBuffer(FRuntimeMeshBufferUpdateData& InStream, bool bDynamicBuffer)
+	static FBufferRHIRef CreateRHIBuffer(FRuntimeMeshBufferUpdateData& InStream, bool bDynamicBuffer)
 	{
 		const uint32 SizeInBytes = InStream.GetResourceDataSize();
 
@@ -227,7 +227,7 @@ public:
 
 
 	template <uint32 MaxNumUpdates>
-	void UpdateRHIFromExisting(FRHIVertexBuffer* IntermediateBuffer, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
+	void UpdateRHIFromExisting(FRHIBuffer* IntermediateBuffer, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
 	{
 		check(VertexBufferRHI && IntermediateBuffer);
 
@@ -239,7 +239,7 @@ public:
 		}
 	}
 
-	void InitRHIFromExisting(const FVertexBufferRHIRef& InVertexBufferRHI)
+	void InitRHIFromExisting(const FBufferRHIRef& InVertexBufferRHI)
 	{
 		InitResource();
 		check(InVertexBufferRHI);
@@ -275,7 +275,7 @@ public:
 	}
 
 	template <uint32 MaxNumUpdates>
-	void UpdateRHIFromExisting(FRHIVertexBuffer* IntermediateBuffer, int32 NumElements, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
+	void UpdateRHIFromExisting(FRHIBuffer* IntermediateBuffer, int32 NumElements, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
 	{
 		if (VertexBufferRHI && IntermediateBuffer)
 		{
@@ -286,7 +286,7 @@ public:
 		}
 	}
 
-	void InitRHIFromExisting(const FVertexBufferRHIRef& InVertexBufferRHI, int32 NumElements)
+	void InitRHIFromExisting(const FBufferRHIRef& InVertexBufferRHI, int32 NumElements)
 	{
 		VertexSize = sizeof(FVector);
 		NumVertices = NumElements;
@@ -348,7 +348,7 @@ public:
 	}
 
 	template <uint32 MaxNumUpdates>
-	void UpdateRHIFromExisting(FRHIVertexBuffer* IntermediateBuffer, int32 NumElements, bool bShouldUseHighPrecision, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
+	void UpdateRHIFromExisting(FRHIBuffer* IntermediateBuffer, int32 NumElements, bool bShouldUseHighPrecision, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
 	{
 		if (VertexBufferRHI && IntermediateBuffer)
 		{
@@ -360,7 +360,7 @@ public:
 		}
 	}
 
-	void InitRHIFromExisting(const FVertexBufferRHIRef& InVertexBufferRHI, int32 NumElements, bool bShouldUseHighPrecision)
+	void InitRHIFromExisting(const FBufferRHIRef& InVertexBufferRHI, int32 NumElements, bool bShouldUseHighPrecision)
 	{
 		bUseHighPrecision = bShouldUseHighPrecision;
 		VertexSize = CalculateStride(bShouldUseHighPrecision);
@@ -439,7 +439,7 @@ public:
 	}
 
 	template <uint32 MaxNumUpdates>
-	void UpdateRHIFromExisting(FRHIVertexBuffer* IntermediateBuffer, int32 NumElements, bool bShouldUseHighPrecision, int32 NumChannels, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
+	void UpdateRHIFromExisting(FRHIBuffer* IntermediateBuffer, int32 NumElements, bool bShouldUseHighPrecision, int32 NumChannels, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
 	{
 		if (VertexBufferRHI && IntermediateBuffer)
 		{
@@ -452,7 +452,7 @@ public:
 		}
 	}
 
-	void InitRHIFromExisting(const FVertexBufferRHIRef& InVertexBufferRHI, int32 NumElements, bool bShouldUseHighPrecision, int32 NumChannels)
+	void InitRHIFromExisting(const FBufferRHIRef& InVertexBufferRHI, int32 NumElements, bool bShouldUseHighPrecision, int32 NumChannels)
 	{
 		bUseHighPrecision = bShouldUseHighPrecision;
 		NumUVs = NumChannels;
@@ -485,7 +485,7 @@ public:
 	}
 
 	template <uint32 MaxNumUpdates>
-	void UpdateRHIFromExisting(FRHIVertexBuffer* IntermediateBuffer, int32 NumElements, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
+	void UpdateRHIFromExisting(FRHIBuffer* IntermediateBuffer, int32 NumElements, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
 	{
 		if (VertexBufferRHI && IntermediateBuffer)
 		{
@@ -496,7 +496,7 @@ public:
 		}
 	}
 
-	void InitRHIFromExisting(const FVertexBufferRHIRef& InVertexBufferRHI, int32 NumElements)
+	void InitRHIFromExisting(const FBufferRHIRef& InVertexBufferRHI, int32 NumElements)
 	{
 		VertexSize = sizeof(FColor);
 		NumVertices = NumElements;
@@ -548,24 +548,24 @@ public:
 
 
 	template<bool bIsInRenderThread>
-	static FIndexBufferRHIRef CreateRHIBuffer(FRHIResourceCreateInfo& CreateInfo, uint32 IndexSize, uint32 SizeInBytes, bool bDynamicBuffer)
+	static FBufferRHIRef CreateRHIBuffer(FRHIResourceCreateInfo& CreateInfo, uint32 IndexSize, uint32 SizeInBytes, bool bDynamicBuffer)
 	{
-		const int32 Flags = (bDynamicBuffer ? BUF_Dynamic : BUF_Static) | BUF_ShaderResource;
+//		const int32 Flags = (bDynamicBuffer ? BUF_Dynamic : BUF_Static) | BUF_ShaderResource;
 		CreateInfo.bWithoutNativeResource = SizeInBytes <= 0;
 		if (bIsInRenderThread)
 		{
-			return RHICreateIndexBuffer(IndexSize, SizeInBytes, Flags, CreateInfo);
+			return RHICreateIndexBuffer(IndexSize, SizeInBytes, (bDynamicBuffer ? BUF_Dynamic : BUF_Static) | BUF_ShaderResource, CreateInfo);
 		}
 		else
 		{
-			return RHIAsyncCreateIndexBuffer(IndexSize, SizeInBytes, Flags, CreateInfo);
+			return RHIAsyncCreateIndexBuffer(IndexSize, SizeInBytes, (bDynamicBuffer ? BUF_Dynamic : BUF_Static) | BUF_ShaderResource, CreateInfo);
 		}
 		return nullptr;
 
 	}
 
 	template<bool bIsInRenderThread>
-	static FIndexBufferRHIRef CreateRHIBuffer(FRuntimeMeshBufferUpdateData& InStream, bool bDynamicBuffer)
+	static FBufferRHIRef CreateRHIBuffer(FRuntimeMeshBufferUpdateData& InStream, bool bDynamicBuffer)
 	{
 		const uint32 SizeInBytes = InStream.GetResourceDataSize();
 
@@ -576,7 +576,7 @@ public:
 
 
 	template <uint32 MaxNumUpdates>
-	void UpdateRHIFromExisting(FRHIIndexBuffer* IntermediateBuffer, int32 NumElements, bool bShouldUseHighPrecision, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
+	void UpdateRHIFromExisting(FRHIBuffer* IntermediateBuffer, int32 NumElements, bool bShouldUseHighPrecision, TRHIResourceUpdateBatcher<MaxNumUpdates>& Batcher)
 	{
 		if (IndexBufferRHI && IntermediateBuffer)
 		{
@@ -587,7 +587,7 @@ public:
 		}
 	}
 
-	void InitRHIFromExisting(const FIndexBufferRHIRef& InIndexBufferRHI, int32 NumElements, bool bShouldUseHighPrecision)
+	void InitRHIFromExisting(const FBufferRHIRef& InIndexBufferRHI, int32 NumElements, bool bShouldUseHighPrecision)
 	{
 		InitResource();
 

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshSlicer.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshSlicer.cpp
@@ -50,7 +50,7 @@ int32 CopyVertexToNewMeshData(const FRuntimeMeshRenderableMeshData& Source, FRun
 
 	int32 NewIndex = Destination.Positions.Add(Source.Positions.GetPosition(Index));
 
-	FVector TangentX, TangentY, TangentZ;
+	FVector3f TangentX, TangentY, TangentZ;
 	if (Source.Triangles.Num() > Index)
 	{
 		Source.Tangents.GetTangents(Index, TangentX, TangentY, TangentZ);
@@ -78,14 +78,14 @@ int32 AddInterpolatedVert(FRuntimeMeshRenderableMeshData& Source, FRuntimeMeshRe
 		return CopyVertexToNewMeshData(Source, Destination, Vertex1);
 	}
 
-	FVector LeftPosition = Source.Positions.GetPosition(Vertex0);
-	FVector RightPosition = Source.Positions.GetPosition(Vertex1);
+	FVector3f LeftPosition = Source.Positions.GetPosition(Vertex0);
+	FVector3f RightPosition = Source.Positions.GetPosition(Vertex1);
 	int32 NewIndex = Destination.Positions.Add(FMath::Lerp(LeftPosition, RightPosition, Alpha));
 
 	if (Source.Tangents.Num() > MaxVertex)
 	{
-		FVector LeftTangentX, LeftTangentY, LeftTangentZ;
-		FVector RightTangentX, RightTangentY, RightTangentZ;
+		FVector3f LeftTangentX, LeftTangentY, LeftTangentZ;
+		FVector3f RightTangentX, RightTangentY, RightTangentZ;
 		Source.Tangents.GetTangents(Vertex0, LeftTangentX, LeftTangentY, LeftTangentZ);
 		Source.Tangents.GetTangents(Vertex1, RightTangentX, RightTangentY, RightTangentZ);
 
@@ -96,7 +96,7 @@ int32 AddInterpolatedVert(FRuntimeMeshRenderableMeshData& Source, FRuntimeMeshRe
 	}
 	else if (Source.Tangents.Num() > 0)
 	{
-		FVector TangentX, TangentY, TangentZ;
+		FVector3f TangentX, TangentY, TangentZ;
 		Source.Tangents.GetTangents(Vertex0, TangentX, TangentY, TangentZ);
 
 		Destination.Tangents.Add(TangentX, TangentY, TangentZ);
@@ -151,7 +151,7 @@ void Transform2DPolygonTo3D(const FUtilPoly2D& InPoly, const FMatrix& InMatrix, 
 	{
 		const FUtilVertex2D& InVertex = InPoly.Verts[VertexIndex];
 
-		OutMeshData.Positions.Add(InMatrix.TransformPosition(FVector(InVertex.Pos.X, InVertex.Pos.Y, 0.f)));
+		OutMeshData.Positions.Add((FVector3f)FVector3d(InMatrix.TransformPosition(FVector(InVertex.Pos.X, InVertex.Pos.Y, 0.f))));
 		OutMeshData.Tangents.Add(TangentX, TangentY, TangentZ);
 		OutMeshData.Colors.Add(InVertex.Color);
 		OutMeshData.TexCoords.Add(InVertex.UV);
@@ -772,7 +772,7 @@ void URuntimeMeshSlicer::SliceRuntimeMesh(URuntimeMeshComponent* InRuntimeMesh, 
 			{
 				NewDestiantionCap.Positions.Add(NewSourceCap.Positions.GetPosition(VertIdx));
 
-				FVector TangentX, TangentY, TangentZ;
+				FVector3f TangentX, TangentY, TangentZ;
 				NewSourceCap.Tangents.GetTangents(VertIdx, TangentX, TangentY, TangentZ);
 				TangentX *= -1.0f;
 				TangentY *= -1.0f;

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshSlicer.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshSlicer.cpp
@@ -59,7 +59,7 @@ int32 CopyVertexToNewMeshData(const FRuntimeMeshRenderableMeshData& Source, FRun
 
 	Destination.Colors.Add(Source.Colors.Num() > Index ? Source.Colors.GetColor(Index) : FColor::White);
 
-	Destination.TexCoords.Add(Source.TexCoords.Num() > Index ? Source.TexCoords.GetTexCoord(Index) : FVector2D(0, 0));
+	Destination.TexCoords.Add(Source.TexCoords.Num() > Index ? Source.TexCoords.GetTexCoord(Index) : FVector2f(0, 0));
 
 	return NewIndex;
 }
@@ -103,7 +103,7 @@ int32 AddInterpolatedVert(FRuntimeMeshRenderableMeshData& Source, FRuntimeMeshRe
 	}
 	else
 	{
-		Destination.Tangents.Add(FVector::RightVector, FVector::ForwardVector, FVector::UpVector);
+		Destination.Tangents.Add(FVector3f::RightVector, FVector3f::ForwardVector, FVector3f::UpVector);
 	}
 
 
@@ -128,19 +128,20 @@ int32 AddInterpolatedVert(FRuntimeMeshRenderableMeshData& Source, FRuntimeMeshRe
 
 	if (Source.TexCoords.Num() > MaxVertex)
 	{
-		FVector2D LeftTexCoord = Source.TexCoords.GetTexCoord(Vertex0);
-		FVector2D RightTexCoord = Source.TexCoords.GetTexCoord(Vertex1);
+		FVector2f LeftTexCoord = Source.TexCoords.GetTexCoord(Vertex0);
+		FVector2f RightTexCoord = Source.TexCoords.GetTexCoord(Vertex1);
 		Destination.TexCoords.Add(FMath::Lerp(LeftTexCoord, RightTexCoord, Alpha));
 	}
 	else
 	{
-		Destination.TexCoords.Add(Source.TexCoords.Num() > 0 ? Source.TexCoords.GetTexCoord(0) : FVector2D::ZeroVector);
+		Destination.TexCoords.Add(Source.TexCoords.Num() > 0 ? Source.TexCoords.GetTexCoord(0) : FVector2f::ZeroVector);
 	}
 
 	return NewIndex;
 }
 
 /** Transform triangle from 2D to 3D static-mesh triangle. */
+//NOTE: This uses engine types which are using double precision; not editing to single precision like much of the rest of the code.
 void Transform2DPolygonTo3D(const FUtilPoly2D& InPoly, const FMatrix& InMatrix, FRuntimeMeshRenderableMeshData& OutMeshData)
 {
 	FVector TangentX = -InMatrix.GetUnitAxis(EAxis::X);
@@ -154,7 +155,7 @@ void Transform2DPolygonTo3D(const FUtilPoly2D& InPoly, const FMatrix& InMatrix, 
 		OutMeshData.Positions.Add((FVector3f)FVector3d(InMatrix.TransformPosition(FVector(InVertex.Pos.X, InVertex.Pos.Y, 0.f))));
 		OutMeshData.Tangents.Add(TangentX, TangentY, TangentZ);
 		OutMeshData.Colors.Add(InVertex.Color);
-		OutMeshData.TexCoords.Add(InVertex.UV);
+		OutMeshData.TexCoords.Add(FVector2f(InVertex.UV));
 	}
 }
 

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
@@ -83,7 +83,7 @@ int32 URuntimeMeshStaticMeshConverter::CopyVertexOrGetIndex(const FStaticMeshLOD
 		// Copy UV's
 		for (int32 UVIndex = 0; UVIndex < NumUVChannels; UVIndex++)
 		{
-			NewMeshData.TexCoords.Add(UVIndex, (FVector2f)LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, UVIndex));
+			NewMeshData.TexCoords.Add(UVIndex, FVector2D(LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, UVIndex)));
 		}
 		
 		MeshToSectionVertexMap.Add(VertexIndex, NewVertexIndex);
@@ -198,8 +198,8 @@ bool URuntimeMeshStaticMeshConverter::CopyStaticMeshCollisionToCollisionSettings
 	{
 		bHadSimple = true;
 		OutCollisionSettings.ConvexElements.Emplace(
-			RMC_ConvertTArray<FVector3f>(SourceConvexElems[ConvexIndex].VertexData), 
-			FBox3f(SourceConvexElems[ConvexIndex].ElemBox));
+			SourceConvexElems[ConvexIndex].VertexData, 
+			SourceConvexElems[ConvexIndex].ElemBox);
 	}
 
 	// Copy boxes

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
@@ -40,12 +40,12 @@ int32 URuntimeMeshStaticMeshConverter::CopyVertexOrGetIndex(const FStaticMeshLOD
 		{
 			for (int32 TexIndex = 0; TexIndex < NumTexCoords; TexIndex++)
 			{
-				NewMeshData.TexCoords.Add((FVector2D)LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, TexIndex), TexIndex);
+				NewMeshData.TexCoords.Add((FVector2f)LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, TexIndex), TexIndex);
 			}
 		}
 		else
 		{
-			NewMeshData.TexCoords.Add(FVector2D::ZeroVector);
+			NewMeshData.TexCoords.Add(FVector2f::ZeroVector);
 		}		
 
 		// Copy Color
@@ -83,7 +83,7 @@ int32 URuntimeMeshStaticMeshConverter::CopyVertexOrGetIndex(const FStaticMeshLOD
 		// Copy UV's
 		for (int32 UVIndex = 0; UVIndex < NumUVChannels; UVIndex++)
 		{
-			NewMeshData.TexCoords.Add(UVIndex, (FVector2D)LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, UVIndex));
+			NewMeshData.TexCoords.Add(UVIndex, (FVector2f)LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, UVIndex));
 		}
 		
 		MeshToSectionVertexMap.Add(VertexIndex, NewVertexIndex);
@@ -198,8 +198,8 @@ bool URuntimeMeshStaticMeshConverter::CopyStaticMeshCollisionToCollisionSettings
 	{
 		bHadSimple = true;
 		OutCollisionSettings.ConvexElements.Emplace(
-			SourceConvexElems[ConvexIndex].VertexData, 
-			SourceConvexElems[ConvexIndex].ElemBox);
+			RMC_ConvertTArray<FVector3f>(SourceConvexElems[ConvexIndex].VertexData), 
+			FBox3f(SourceConvexElems[ConvexIndex].ElemBox));
 	}
 
 	// Copy boxes

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
@@ -40,7 +40,7 @@ int32 URuntimeMeshStaticMeshConverter::CopyVertexOrGetIndex(const FStaticMeshLOD
 		{
 			for (int32 TexIndex = 0; TexIndex < NumTexCoords; TexIndex++)
 			{
-				NewMeshData.TexCoords.Add(LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, TexIndex), TexIndex);
+				NewMeshData.TexCoords.Add((FVector2D)LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, TexIndex), TexIndex);
 			}
 		}
 		else
@@ -83,7 +83,7 @@ int32 URuntimeMeshStaticMeshConverter::CopyVertexOrGetIndex(const FStaticMeshLOD
 		// Copy UV's
 		for (int32 UVIndex = 0; UVIndex < NumUVChannels; UVIndex++)
 		{
-			NewMeshData.TexCoords.Add(UVIndex, LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, UVIndex));
+			NewMeshData.TexCoords.Add(UVIndex, (FVector2D)LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, UVIndex));
 		}
 		
 		MeshToSectionVertexMap.Add(VertexIndex, NewVertexIndex);
@@ -94,7 +94,7 @@ int32 URuntimeMeshStaticMeshConverter::CopyVertexOrGetIndex(const FStaticMeshLOD
 bool URuntimeMeshStaticMeshConverter::CopyStaticMeshSectionToRenderableMeshData(UStaticMesh* StaticMesh, int32 LODIndex, int32 SectionId, FRuntimeMeshRenderableMeshData& OutMeshData)
 {
 	// Check valid static mesh
-	if (StaticMesh == nullptr || StaticMesh->IsPendingKill())
+	if (!IsValid(StaticMesh))
 	{
 		return false;
 	}
@@ -173,7 +173,7 @@ bool URuntimeMeshStaticMeshConverter::CopyStaticMeshSectionToRenderableMeshData(
 bool URuntimeMeshStaticMeshConverter::CopyStaticMeshCollisionToCollisionSettings(UStaticMesh* StaticMesh, FRuntimeMeshCollisionSettings& OutCollisionSettings)
 {
 	// Check valid static mesh
-	if (StaticMesh == nullptr || StaticMesh->IsPendingKill())
+	if (!IsValid(StaticMesh))
 	{
 		return false;
 	}
@@ -248,7 +248,7 @@ bool URuntimeMeshStaticMeshConverter::CopyStaticMeshCollisionToCollisionSettings
 bool URuntimeMeshStaticMeshConverter::CopyStaticMeshLODToCollisionData(UStaticMesh* StaticMesh, int32 LODIndex, FRuntimeMeshCollisionData& OutCollisionData)
 {
 	// Check valid static mesh
-	if (StaticMesh == nullptr || StaticMesh->IsPendingKill())
+	if (!IsValid(StaticMesh))
 	{
 		return false;
 	}
@@ -330,7 +330,7 @@ bool URuntimeMeshStaticMeshConverter::CopyStaticMeshToRuntimeMesh(UStaticMesh* S
 
 
 	// Check valid static mesh
-	if (StaticMesh == nullptr || StaticMesh->IsPendingKill())
+	if (!IsValid(StaticMesh))
 	{
 		RMC_LOG_VERBOSE(RuntimeMeshComponent->GetRuntimeMeshId(), "Unable to convert StaticMesh to RuntimeMesh. Invalid source StaticMesh.");
 		StaticProvider->ConfigureLODs({ FRuntimeMeshLODProperties() });

--- a/Source/RuntimeMeshComponent/Public/Components/RuntimeMeshComponentStatic.h
+++ b/Source/RuntimeMeshComponent/Public/Components/RuntimeMeshComponentStatic.h
@@ -40,6 +40,8 @@ public:
 	void CreateSection_Blueprint(int32 LODIndex, int32 SectionId, const FRuntimeMeshSectionProperties& SectionProperties, const FRuntimeMeshRenderableMeshData& SectionData);
 
 	/**
+	*	NOTE: For Blueprint compatibility, this function converts inputs from double precision to single precision.
+	*   Use single precision (FVector3f, FVector2f) versions for C++ code!
 	*	Create/replace a section for this runtime mesh.
 	*	@param	LODIndex			Index of the LOD to create the section in.
 	*	@param	SectionIndex		Index of the section to create or replace.
@@ -78,8 +80,29 @@ public:
 	*	@param	UpdateFrequency		How frequently this section is expected to be updated, Infrequent draws faster than Average/Frequent but updates slower
 	*	@param	bCreateCollision	Indicates whether collision should be created for this section. This adds significant cost.
 	*/
-	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-		const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FColor>& VertexColors,
+	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FLinearColor>& VertexColors,
+		const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency = ERuntimeMeshUpdateFrequency::Infrequent, bool bCreateCollision = true);
+
+	/**
+	*	Create/replace a section for this runtime mesh.
+	*	@param	LODIndex			Index of the LOD to create the section in.
+	*	@param	SectionIndex		Index of the section to create or replace.
+	*	@param	MaterialSlot		Index of the material to use for this section
+	*	@param	Vertices			Vertex buffer of all vertex positions to use for this mesh section.
+	*	@param	Triangles			Index buffer indicating which vertices make up each triangle. Length must be a multiple of 3.
+	*	@param	Normals				Optional array of normal vectors for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV0					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV1					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV2					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV3					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	VertexColors		Optional array of colors for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	Tangents			Optional array of tangent vector for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UpdateFrequency		How frequently this section is expected to be updated, Infrequent draws faster than Average/Frequent but updates slower
+	*	@param	bCreateCollision	Indicates whether collision should be created for this section. This adds significant cost.
+	*/
+	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FColor>& VertexColors,
 		const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency = ERuntimeMeshUpdateFrequency::Infrequent, bool bCreateCollision = true);
 
 	/**
@@ -96,8 +119,8 @@ public:
 	*	@param	UpdateFrequency		How frequently this section is expected to be updated, Infrequent draws faster than Average/Frequent but updates slower
 	*	@param	bCreateCollision	Indicates whether collision should be created for this section. This adds significant cost.
 	*/
-	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-		const TArray<FVector2D>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
+	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
 		ERuntimeMeshUpdateFrequency UpdateFrequency = ERuntimeMeshUpdateFrequency::Infrequent, bool bCreateCollision = true);
 
 
@@ -115,14 +138,16 @@ public:
 	*	@param	UpdateFrequency		How frequently this section is expected to be updated, Infrequent draws faster than Average/Frequent but updates slower
 	*	@param	bCreateCollision	Indicates whether collision should be created for this section. This adds significant cost.
 	*/
-	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-		const TArray<FVector2D>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
+	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
 		ERuntimeMeshUpdateFrequency UpdateFrequency = ERuntimeMeshUpdateFrequency::Infrequent, bool bCreateCollision = true);
 
 	UFUNCTION(BlueprintCallable, Category = "RuntimeMeshStatic|Mesh", Meta = (DisplayName = "Update Section"))
 	void UpdateSection_Blueprint(int32 LODIndex, int32 SectionId, const FRuntimeMeshRenderableMeshData& SectionData);
 
 	/**
+	*	NOTE: For Blueprint compatibility, this function converts inputs from double precision to single precision.
+	*   Use single precision (FVector3f, FVector2f) versions for C++ code!
 	*	Update the mesh data of a section.
 	*	@param	LODIndex			Index of the LOD to create the section in.
 	*	@param	SectionIndex		Index of the section to create or replace.
@@ -154,8 +179,25 @@ public:
 	*	@param	VertexColors		Optional array of colors for each vertex. If supplied, must be same length as Vertices array.
 	*	@param	Tangents			Optional array of tangent vector for each vertex. If supplied, must be same length as Vertices array.
 	*/
-	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, const TArray<FVector2D>& UV0,
-		const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
+	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals, const TArray<FVector2f>& UV0,
+		const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
+
+	/**
+	*	Update the mesh data of a section.
+	*	@param	LODIndex			Index of the LOD to create the section in.
+	*	@param	SectionIndex		Index of the section to create or replace.
+	*	@param	Vertices			Vertex buffer of all vertex positions to use for this mesh section.
+	*	@param	Triangles			Index buffer indicating which vertices make up each triangle. Length must be a multiple of 3.
+	*	@param	Normals				Optional array of normal vectors for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV0					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV1					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV2					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV3					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	VertexColors		Optional array of colors for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	Tangents			Optional array of tangent vector for each vertex. If supplied, must be same length as Vertices array.
+	*/
+	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals, const TArray<FVector2f>& UV0,
+		const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
 
 	/**
 	*	Update the mesh data of a section.
@@ -168,8 +210,8 @@ public:
 	*	@param	VertexColors		Optional array of colors for each vertex. If supplied, must be same length as Vertices array.
 	*	@param	Tangents			Optional array of tangent vector for each vertex. If supplied, must be same length as Vertices array.
 	*/
-	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-		const TArray<FVector2D>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
+	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
 
 
 	/**
@@ -183,8 +225,8 @@ public:
 	*	@param	VertexColors		Optional array of colors for each vertex. If supplied, must be same length as Vertices array.
 	*	@param	Tangents			Optional array of tangent vector for each vertex. If supplied, must be same length as Vertices array.
 	*/
-	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-		const TArray<FVector2D>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
+	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
 
 	UFUNCTION(BlueprintCallable, Category = "RuntimeMeshStatic|Mesh", Meta = (DisplayName = "Clear Section"))
 	void ClearSection(int32 LODIndex, int32 SectionId);

--- a/Source/RuntimeMeshComponent/Public/Modifiers/RuntimeMeshModifierAdjacency.h
+++ b/Source/RuntimeMeshComponent/Public/Modifiers/RuntimeMeshModifierAdjacency.h
@@ -33,7 +33,7 @@ private:
 	struct Corner;
 	struct Triangle;
 
-	static FORCEINLINE uint32 HashValue(const FVector& Vec)
+	static FORCEINLINE uint32 HashValue(const FVector3f& Vec)
 	{
 		return 31337 * GetTypeHash(Vec.X) + 13 * GetTypeHash(Vec.Y) + 3 * GetTypeHash(Vec.Z);
 	}
@@ -48,11 +48,11 @@ private:
 
 	struct Vertex
 	{
-		FVector Position;
-		FVector2D TexCoord;
+		FVector3f Position;
+		FVector2f TexCoord;
 
 		Vertex() { }
-		Vertex(const FVector& InPosition, const FVector2D& InTexCoord)
+		Vertex(const FVector3f& InPosition, const FVector2f& InTexCoord)
 			: Position(InPosition), TexCoord(InTexCoord)
 		{ }
 
@@ -148,10 +148,10 @@ private:
 	struct Corner
 	{
 		uint32 Index;
-		FVector2D TexCoord;
+		FVector2f TexCoord;
 
 		Corner() : Index(0) { }
-		Corner(uint32 InIndex, FVector2D InTexCoord)
+		Corner(uint32 InIndex, FVector2f InTexCoord)
 			: Index(InIndex), TexCoord(InTexCoord)
 		{ }
 	};

--- a/Source/RuntimeMeshComponent/Public/Providers/RuntimeMeshProviderStatic.h
+++ b/Source/RuntimeMeshComponent/Public/Providers/RuntimeMeshProviderStatic.h
@@ -68,6 +68,8 @@ public:
 	}
 
 	/**
+	*	NOTE: For Blueprint compatibility, this function converts inputs from double precision to single precision.
+	*   Use single precision (FVector3f, FVector2f) versions for C++ code!
 	*	Create/replace a section for this runtime mesh.
 	*	@param	LODIndex			Index of the LOD to create the section in.
 	*	@param	SectionIndex		Index of the section to create or replace.
@@ -88,7 +90,6 @@ public:
 	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
 		const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FLinearColor>& VertexColors, 
 		const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency = ERuntimeMeshUpdateFrequency::Infrequent, bool bCreateCollision = true);
-	
 
 	/**
 	*	Create/replace a section for this runtime mesh.
@@ -107,8 +108,29 @@ public:
 	*	@param	UpdateFrequency		How frequently this section is expected to be updated, Infrequent draws faster than Average/Frequent but updates slower
 	*	@param	bCreateCollision	Indicates whether collision should be created for this section. This adds significant cost.
 	*/
-	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-		const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FColor>& VertexColors, 
+	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FLinearColor>& VertexColors,
+		const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency = ERuntimeMeshUpdateFrequency::Infrequent, bool bCreateCollision = true);
+
+	/**
+	*	Create/replace a section for this runtime mesh.
+	*	@param	LODIndex			Index of the LOD to create the section in.
+	*	@param	SectionIndex		Index of the section to create or replace.
+	*	@param	MaterialSlot		Index of the material to use for this section
+	*	@param	Vertices			Vertex buffer of all vertex positions to use for this mesh section.
+	*	@param	Triangles			Index buffer indicating which vertices make up each triangle. Length must be a multiple of 3.
+	*	@param	Normals				Optional array of normal vectors for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV0					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV1					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV2					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV3					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	VertexColors		Optional array of colors for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	Tangents			Optional array of tangent vector for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UpdateFrequency		How frequently this section is expected to be updated, Infrequent draws faster than Average/Frequent but updates slower
+	*	@param	bCreateCollision	Indicates whether collision should be created for this section. This adds significant cost.
+	*/
+	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FColor>& VertexColors, 
 		const TArray<FRuntimeMeshTangent>& Tangents, ERuntimeMeshUpdateFrequency UpdateFrequency = ERuntimeMeshUpdateFrequency::Infrequent, bool bCreateCollision = true);
 
 	/**
@@ -125,8 +147,8 @@ public:
 	*	@param	UpdateFrequency		How frequently this section is expected to be updated, Infrequent draws faster than Average/Frequent but updates slower
 	*	@param	bCreateCollision	Indicates whether collision should be created for this section. This adds significant cost.
 	*/
-	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-		const TArray<FVector2D>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
+	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
 		ERuntimeMeshUpdateFrequency UpdateFrequency = ERuntimeMeshUpdateFrequency::Infrequent, bool bCreateCollision = true);
 
 
@@ -144,14 +166,16 @@ public:
 	*	@param	UpdateFrequency		How frequently this section is expected to be updated, Infrequent draws faster than Average/Frequent but updates slower
 	*	@param	bCreateCollision	Indicates whether collision should be created for this section. This adds significant cost.
 	*/
-	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-		const TArray<FVector2D>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
+	void CreateSectionFromComponents(int32 LODIndex, int32 SectionIndex, int32 MaterialSlot, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents,
 		ERuntimeMeshUpdateFrequency UpdateFrequency = ERuntimeMeshUpdateFrequency::Infrequent, bool bCreateCollision = true);
 
 
 
 
 	/**
+	*	NOTE: For Blueprint compatibility, this function converts inputs from double precision to single precision.
+	*   Use single precision (FVector3f, FVector2f) versions for C++ code!
 	*	Update the mesh data of a section.
 	*	@param	LODIndex			Index of the LOD to create the section in.
 	*	@param	SectionIndex		Index of the section to create or replace.
@@ -169,6 +193,23 @@ public:
 	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, 
 		const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
 
+	/**
+	*	Update the mesh data of a section.
+	*	@param	LODIndex			Index of the LOD to create the section in.
+	*	@param	SectionIndex		Index of the section to create or replace.
+	*	@param	Vertices			Vertex buffer of all vertex positions to use for this mesh section.
+	*	@param	Triangles			Index buffer indicating which vertices make up each triangle. Length must be a multiple of 3.
+	*	@param	Normals				Optional array of normal vectors for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV0					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV1					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV2					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	UV3					Optional array of texture co-ordinates for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	VertexColors		Optional array of colors for each vertex. If supplied, must be same length as Vertices array.
+	*	@param	Tangents			Optional array of tangent vector for each vertex. If supplied, must be same length as Vertices array.
+	*/
+	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals, const TArray<FVector2f>& UV0,
+		const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
+
 
 	/**
 	*	Update the mesh data of a section.
@@ -184,8 +225,8 @@ public:
 	*	@param	VertexColors		Optional array of colors for each vertex. If supplied, must be same length as Vertices array.
 	*	@param	Tangents			Optional array of tangent vector for each vertex. If supplied, must be same length as Vertices array.
 	*/
-	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals, const TArray<FVector2D>& UV0, 
-		const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
+	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals, const TArray<FVector2f>& UV0, 
+		const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
 
 	/**
 	*	Update the mesh data of a section.
@@ -198,8 +239,8 @@ public:
 	*	@param	VertexColors		Optional array of colors for each vertex. If supplied, must be same length as Vertices array.
 	*	@param	Tangents			Optional array of tangent vector for each vertex. If supplied, must be same length as Vertices array.
 	*/
-	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-		const TArray<FVector2D>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
+	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FLinearColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
 
 
 	/**
@@ -213,8 +254,8 @@ public:
 	*	@param	VertexColors		Optional array of colors for each vertex. If supplied, must be same length as Vertices array.
 	*	@param	Tangents			Optional array of tangent vector for each vertex. If supplied, must be same length as Vertices array.
 	*/
-	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
-		const TArray<FVector2D>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
+	void UpdateSectionFromComponents(int32 LODIndex, int32 SectionIndex, const TArray<FVector3f>& Vertices, const TArray<int32>& Triangles, const TArray<FVector3f>& Normals,
+		const TArray<FVector2f>& UV0, const TArray<FColor>& VertexColors, const TArray<FRuntimeMeshTangent>& Tangents);
 
 
 
@@ -345,26 +386,11 @@ public:
 	virtual void Serialize(FArchive& Ar) override;
 	virtual void BeginDestroy() override;
 private:
-	static const TArray<FVector2D> EmptyUVs;
-	
-	template<typename TangentType, typename ColorType>
-	static FRuntimeMeshRenderableMeshData FillMeshData(FRuntimeMeshSectionProperties& Properties, const TArray<FVector>& Vertices, const TArray<FVector>& Normals, const TArray<TangentType>& Tangents,
-		const TArray<ColorType>& VertexColors, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<int32>& Triangles)
-	{
-		TArray<FVector3f> verts;
-		for (FVector v : Vertices) {
-			verts.Add((FVector3f)v);
-		}
-		TArray<FVector3f> norms;
-		for (FVector v : Normals) {
-			norms.Add((FVector3f)v);
-		}
-		return FillMeshData(Properties, verts, norms, Tangents, VertexColors, UV0, UV1, UV2, UV3, Triangles);
-	}
+	static const TArray<FVector2f> EmptyUVs;
 	
 	template<typename TangentType, typename ColorType>
 	static FRuntimeMeshRenderableMeshData FillMeshData(FRuntimeMeshSectionProperties& Properties, const TArray<FVector3f>& Vertices, const TArray<FVector3f>& Normals, const TArray<TangentType>& Tangents,
-		const TArray<ColorType>& VertexColors, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<int32>& Triangles)
+		const TArray<ColorType>& VertexColors, const TArray<FVector2f>& UV0, const TArray<FVector2f>& UV1, const TArray<FVector2f>& UV2, const TArray<FVector2f>& UV3, const TArray<int32>& Triangles)
 	{
 		Properties.bWants32BitIndices = Vertices.Num() > MAX_uint16;
 		Properties.bUseHighPrecisionTexCoords = true;

--- a/Source/RuntimeMeshComponent/Public/Providers/RuntimeMeshProviderStatic.h
+++ b/Source/RuntimeMeshComponent/Public/Providers/RuntimeMeshProviderStatic.h
@@ -346,9 +346,24 @@ public:
 	virtual void BeginDestroy() override;
 private:
 	static const TArray<FVector2D> EmptyUVs;
-
+	
 	template<typename TangentType, typename ColorType>
 	static FRuntimeMeshRenderableMeshData FillMeshData(FRuntimeMeshSectionProperties& Properties, const TArray<FVector>& Vertices, const TArray<FVector>& Normals, const TArray<TangentType>& Tangents,
+		const TArray<ColorType>& VertexColors, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<int32>& Triangles)
+	{
+		TArray<FVector3f> verts;
+		for (FVector v : Vertices) {
+			verts.Add((FVector3f)v);
+		}
+		TArray<FVector3f> norms;
+		for (FVector v : Normals) {
+			norms.Add((FVector3f)v);
+		}
+		return FillMeshData(Properties, verts, norms, Tangents, VertexColors, UV0, UV1, UV2, UV3, Triangles);
+	}
+	
+	template<typename TangentType, typename ColorType>
+	static FRuntimeMeshRenderableMeshData FillMeshData(FRuntimeMeshSectionProperties& Properties, const TArray<FVector3f>& Vertices, const TArray<FVector3f>& Normals, const TArray<TangentType>& Tangents,
 		const TArray<ColorType>& VertexColors, const TArray<FVector2D>& UV0, const TArray<FVector2D>& UV1, const TArray<FVector2D>& UV2, const TArray<FVector2D>& UV3, const TArray<int32>& Triangles)
 	{
 		Properties.bWants32BitIndices = Vertices.Num() > MAX_uint16;
@@ -368,7 +383,7 @@ private:
 			SectionData.Tangents.SetNum(SectionData.Positions.Num());
 			for (int32 Index = Count; Index < SectionData.Tangents.Num(); Index++)
 			{
-				SectionData.Tangents.SetTangents(Index, FVector(1, 0, 0), FVector(0, 1, 0), FVector(0, 0, 1));
+				SectionData.Tangents.SetTangents(Index, FVector3f(1, 0, 0), FVector3f(0, 1, 0), FVector3f(0, 0, 1));
 			}
 		}
 		SectionData.Colors.Append(VertexColors);

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
@@ -19,31 +19,31 @@ struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshCollisionConvexMesh
 
 public:
 	FRuntimeMeshCollisionConvexMesh() : BoundingBox(ForceInit) { }
-	FRuntimeMeshCollisionConvexMesh(const TArray<FVector>& InVertexBuffer)
+	FRuntimeMeshCollisionConvexMesh(const TArray<FVector3f>& InVertexBuffer)
 		: VertexBuffer(InVertexBuffer)
 		, BoundingBox(InVertexBuffer)
 	{
 	}
-	FRuntimeMeshCollisionConvexMesh(TArray<FVector>&& InVertexBuffer)
+	FRuntimeMeshCollisionConvexMesh(TArray<FVector3f>&& InVertexBuffer)
 		: VertexBuffer(InVertexBuffer)
 		, BoundingBox(VertexBuffer)
 	{
 	}
-	FRuntimeMeshCollisionConvexMesh(const TArray<FVector>& InVertexBuffer, const FBox& InBoundingBox)
+	FRuntimeMeshCollisionConvexMesh(const TArray<FVector3f>& InVertexBuffer, const FBox3f& InBoundingBox)
 		: VertexBuffer(InVertexBuffer)
 		, BoundingBox(InBoundingBox)
 	{
 	}
-	FRuntimeMeshCollisionConvexMesh(TArray<FVector>&& InVertexBuffer, const FBox& InBoundingBox)
+	FRuntimeMeshCollisionConvexMesh(TArray<FVector3f>&& InVertexBuffer, const FBox3f& InBoundingBox)
 		: VertexBuffer(InVertexBuffer)
 		, BoundingBox(VertexBuffer)
 	{
 	}
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RuntimeMesh|Collision|Convex")
-	TArray<FVector> VertexBuffer;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RuntimeMesh|Collision|Convex")
-	FBox BoundingBox;
+	TArray<FVector3f> VertexBuffer;
+	//UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RuntimeMesh|Collision|Convex")
+	FBox3f BoundingBox;
 
 	friend FArchive& operator <<(FArchive& Ar, FRuntimeMeshCollisionConvexMesh& Section)
 	{
@@ -224,7 +224,7 @@ struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshCollisionVertexStream
 	GENERATED_USTRUCT_BODY()
 
 private:
-	TArray<FVector> Data;
+	TArray<FVector3f> Data;
 
 public:
 	FRuntimeMeshCollisionVertexStream() { }
@@ -249,23 +249,23 @@ public:
 		Data.Reserve(Number);
 	}
 
-	FORCEINLINE int32 Add(const FVector& InPosition)
+	FORCEINLINE int32 Add(const FVector3f& InPosition)
 	{
 		return Data.Add(InPosition);
 	}
 
-	FORCEINLINE const FVector& GetPosition(int32 Index) const
+	FORCEINLINE const FVector3f& GetPosition(int32 Index) const
 	{
 		return Data[Index];
 	}
 
-	FORCEINLINE void SetPosition(int32 Index, const FVector& NewPosition)
+	FORCEINLINE void SetPosition(int32 Index, const FVector3f& NewPosition)
 	{
 		Data[Index] = NewPosition;
 	}
 
 private:
-	TArray<FVector>&& TakeContents()
+	TArray<FVector3f>&& TakeContents()
 	{
 		return MoveTemp(Data);
 	}
@@ -392,7 +392,7 @@ struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshCollisionTexCoordStream
 	GENERATED_USTRUCT_BODY()
 
 private:
-	TArray<TArray<FVector2D>> Data;
+	TArray<TArray<FVector2f>> Data;
 
 public:
 	FRuntimeMeshCollisionTexCoordStream()
@@ -451,22 +451,22 @@ public:
 		Data[ChannelId].Empty(Slack);
 	}
 
-	FORCEINLINE int32 Add(int32 ChannelId, const FVector2D& NewTexCoord)
+	FORCEINLINE int32 Add(int32 ChannelId, const FVector2f& NewTexCoord)
 	{
 		return Data[ChannelId].Add(NewTexCoord);
 	}
 
-	FORCEINLINE FVector2D GetTexCoord(int32 ChannelId, int32 TexCoordIndex) const
+	FORCEINLINE FVector2f GetTexCoord(int32 ChannelId, int32 TexCoordIndex) const
 	{
 		return Data[ChannelId][TexCoordIndex];
 	}
 
-	FORCEINLINE void SetTexCoord(int32 ChannelId, int32 TexCoordIndex, const FVector2D& NewTexCoord)
+	FORCEINLINE void SetTexCoord(int32 ChannelId, int32 TexCoordIndex, const FVector2f& NewTexCoord)
 	{
 		Data[ChannelId][TexCoordIndex] = NewTexCoord;
 	}
 private:
-	TArray<TArray<FVector2D>>&& TakeContents()
+	TArray<TArray<FVector2f>>&& TakeContents()
 	{
 		return MoveTemp(Data);
 	}

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
@@ -19,31 +19,31 @@ struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshCollisionConvexMesh
 
 public:
 	FRuntimeMeshCollisionConvexMesh() : BoundingBox(ForceInit) { }
-	FRuntimeMeshCollisionConvexMesh(const TArray<FVector3f>& InVertexBuffer)
+	FRuntimeMeshCollisionConvexMesh(const TArray<FVector>& InVertexBuffer)
 		: VertexBuffer(InVertexBuffer)
 		, BoundingBox(InVertexBuffer)
 	{
 	}
-	FRuntimeMeshCollisionConvexMesh(TArray<FVector3f>&& InVertexBuffer)
+	FRuntimeMeshCollisionConvexMesh(TArray<FVector>&& InVertexBuffer)
 		: VertexBuffer(InVertexBuffer)
 		, BoundingBox(VertexBuffer)
 	{
 	}
-	FRuntimeMeshCollisionConvexMesh(const TArray<FVector3f>& InVertexBuffer, const FBox3f& InBoundingBox)
+	FRuntimeMeshCollisionConvexMesh(const TArray<FVector>& InVertexBuffer, const FBox& InBoundingBox)
 		: VertexBuffer(InVertexBuffer)
 		, BoundingBox(InBoundingBox)
 	{
 	}
-	FRuntimeMeshCollisionConvexMesh(TArray<FVector3f>&& InVertexBuffer, const FBox3f& InBoundingBox)
+	FRuntimeMeshCollisionConvexMesh(TArray<FVector>&& InVertexBuffer, const FBox& InBoundingBox)
 		: VertexBuffer(InVertexBuffer)
-		, BoundingBox(VertexBuffer)
+		, BoundingBox(InBoundingBox)
 	{
 	}
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RuntimeMesh|Collision|Convex")
-	TArray<FVector3f> VertexBuffer;
-	//UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RuntimeMesh|Collision|Convex")
-	FBox3f BoundingBox;
+	TArray<FVector> VertexBuffer;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RuntimeMesh|Collision|Convex")
+	FBox BoundingBox;
 
 	friend FArchive& operator <<(FArchive& Ar, FRuntimeMeshCollisionConvexMesh& Section)
 	{
@@ -392,7 +392,7 @@ struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshCollisionTexCoordStream
 	GENERATED_USTRUCT_BODY()
 
 private:
-	TArray<TArray<FVector2f>> Data;
+	TArray<TArray<FVector2D>> Data;
 
 public:
 	FRuntimeMeshCollisionTexCoordStream()
@@ -451,22 +451,22 @@ public:
 		Data[ChannelId].Empty(Slack);
 	}
 
-	FORCEINLINE int32 Add(int32 ChannelId, const FVector2f& NewTexCoord)
+	FORCEINLINE int32 Add(int32 ChannelId, const FVector2D& NewTexCoord)
 	{
 		return Data[ChannelId].Add(NewTexCoord);
 	}
 
-	FORCEINLINE FVector2f GetTexCoord(int32 ChannelId, int32 TexCoordIndex) const
+	FORCEINLINE FVector2D GetTexCoord(int32 ChannelId, int32 TexCoordIndex) const
 	{
 		return Data[ChannelId][TexCoordIndex];
 	}
 
-	FORCEINLINE void SetTexCoord(int32 ChannelId, int32 TexCoordIndex, const FVector2f& NewTexCoord)
+	FORCEINLINE void SetTexCoord(int32 ChannelId, int32 TexCoordIndex, const FVector2D& NewTexCoord)
 	{
 		Data[ChannelId][TexCoordIndex] = NewTexCoord;
 	}
 private:
-	TArray<TArray<FVector2f>>&& TakeContents()
+	TArray<TArray<FVector2D>>&& TakeContents()
 	{
 		return MoveTemp(Data);
 	}

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshCore.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshCore.h
@@ -30,7 +30,7 @@
 
 
 
-#if ENGINE_MAJOR_VERSION >= 5
+#if ENGINE_MAJOR_VERSION < 5
 	// This version of the RMC is only supported by engine version 5.0.0 (Preview 1) and above
 #endif
 

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshCore.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshCore.h
@@ -137,7 +137,7 @@ public:
 
 	/** Direction of X tangent for this vertex */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Tangent)
-	FVector TangentX;
+	FVector3f TangentX;
 
 	/** Bool that indicates whether we should flip the Y tangent when we compute it using cross product */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Tangent)
@@ -153,7 +153,7 @@ public:
 		, bFlipTangentY(bInFlipTangentY)
 	{}
 
-	FRuntimeMeshTangent(FVector InTangentX, bool bInFlipTangentY = false)
+	FRuntimeMeshTangent(FVector3f InTangentX, bool bInFlipTangentY = false)
 		: TangentX(InTangentX)
 		, bFlipTangentY(bInFlipTangentY)
 	{}

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshCore.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshCore.h
@@ -30,8 +30,8 @@
 
 
 
-#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 22
-	// This version of the RMC is only supported by engine version 4.22 and above
+#if ENGINE_MAJOR_VERSION >= 5
+	// This version of the RMC is only supported by engine version 5.0.0 (Preview 1) and above
 #endif
 
 DECLARE_STATS_GROUP(TEXT("RuntimeMesh"), STATGROUP_RuntimeMesh, STATCAT_Advanced);
@@ -285,3 +285,15 @@ struct FRuntimeMeshDistanceFieldData
 };
 
 using FRuntimeMeshDistanceFieldDataPtr = TSharedPtr<FRuntimeMeshDistanceFieldData, ESPMode::ThreadSafe>;
+
+template<typename T_out, typename T_in>
+static TArray<T_out> RMC_ConvertTArray(const TArray<T_in>& from)
+{
+	TArray<T_out> ret;
+	ret.Reserve(from.Num());
+	for (const auto& val : from)
+	{
+		ret.Push((T_out)val);
+	}
+	return ret;
+}

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshRenderable.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshRenderable.h
@@ -18,7 +18,7 @@ private:
 public:
 	FRuntimeMeshVertexPositionStream() { }
 
-	FORCEINLINE int32 GetStride() const { return sizeof(FVector); }
+	FORCEINLINE int32 GetStride() const { return sizeof(FVector3f); }
 
 	FORCEINLINE int32 Num() const
 	{
@@ -37,31 +37,31 @@ public:
 		Data.Empty(Slack * GetStride());
 	}
 
-	int32 Add(const FVector& InPosition)
+	int32 Add(const FVector3f& InPosition)
 	{
 		int32 Index = Data.Num();
-		Data.AddUninitialized(sizeof(FVector));
-		*((FVector*)&Data[Index]) = InPosition;
-		return Index / sizeof(FVector);
+		Data.AddUninitialized(sizeof(FVector3f));
+		*((FVector3f*)&Data[Index]) = InPosition;
+		return Index / sizeof(FVector3f);
 	}
 	void Append(const FRuntimeMeshVertexPositionStream& InOther)
 	{
 		Data.Append(InOther.Data);
 	}
-	void Append(const TArray<FVector>& InPositions)
+	void Append(const TArray<FVector3f>& InPositions)
 	{
 		int32 StartIndex = Data.Num();
-		Data.SetNum(StartIndex + sizeof(FVector) * InPositions.Num());
-		FMemory::Memcpy(Data.GetData() + StartIndex, InPositions.GetData(), InPositions.Num() * sizeof(FVector));
+		Data.SetNum(StartIndex + sizeof(FVector3f) * InPositions.Num());
+		FMemory::Memcpy(Data.GetData() + StartIndex, InPositions.GetData(), InPositions.Num() * sizeof(FVector3f));
 	}
 
-	void SetPosition(int32 Index, const FVector& NewPosition)
+	void SetPosition(int32 Index, const FVector3f& NewPosition)
 	{
-		*((FVector*)&Data[Index * sizeof(FVector)]) = NewPosition;
+		*((FVector3f*)&Data[Index * sizeof(FVector3f)]) = NewPosition;
 	}
-	const FVector& GetPosition(int32 Index) const
+	const FVector3f& GetPosition(int32 Index) const
 	{
-		return *((FVector*)&Data[Index * sizeof(FVector)]);
+		return *((FVector3f*)&Data[Index * sizeof(FVector3f)]);
 	}
 
 	FBox GetBounds() const
@@ -77,9 +77,9 @@ public:
 
 	const uint8* GetData() const { return Data.GetData(); }
 	TArray<uint8>&& TakeData()&& { return MoveTemp(Data); }
-	const TArray<FVector> GetCopy() const
+	const TArray<FVector3f> GetCopy() const
 	{
-		TArray<FVector> OutData;
+		TArray<FVector3f> OutData;
 		OutData.SetNum(Num());
 		FMemory::Memcpy(OutData.GetData(), Data.GetData(), Data.Num());
 		return OutData;
@@ -139,7 +139,7 @@ public:
 		Data.Empty(Slack * GetStride());
 	}
 
-	int32 Add(const FVector& InNormal, const FVector& InTangent)
+	int32 Add(const FVector3f& InNormal, const FVector3f& InTangent)
 	{
 		int32 Index = Data.Num();
 		int32 Stride = GetStride();
@@ -156,7 +156,7 @@ public:
 		}
 		return Index / Stride;
 	}
-	int32 Add(const FVector4& InNormal, const FVector& InTangent)
+	int32 Add(const FVector4f& InNormal, const FVector3f& InTangent)
 	{
 		int32 Index = Data.Num();
 		int32 Stride = GetStride();
@@ -173,7 +173,7 @@ public:
 		}
 		return Index / Stride;
 	}
-	int32 Add(const FVector& InTangentX, const FVector& InTangentY, const FVector& InTangentZ)
+	int32 Add(const FVector3f& InTangentX, const FVector3f& InTangentY, const FVector3f& InTangentZ)
 	{
 		int32 Index = Data.Num();
 		int32 Stride = GetStride();
@@ -181,12 +181,12 @@ public:
 		if (bIsHighPrecision)
 		{
 			*((FPackedRGBA16N*)&Data[Index]) = FPackedRGBA16N(InTangentX);
-			*((FPackedRGBA16N*)&Data[Index + sizeof(FPackedRGBA16N)]) = FPackedRGBA16N(FVector4(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
+			*((FPackedRGBA16N*)&Data[Index + sizeof(FPackedRGBA16N)]) = FPackedRGBA16N(FVector4f(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
 		}
 		else
 		{
 			*((FPackedNormal*)&Data[Index]) = FPackedNormal(InTangentX);
-			*((FPackedNormal*)&Data[Index + sizeof(FPackedNormal)]) = FPackedNormal(FVector4(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
+			*((FPackedNormal*)&Data[Index + sizeof(FPackedNormal)]) = FPackedNormal(FVector4f(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
 		}
 		return Index / Stride;
 	}
@@ -194,7 +194,7 @@ public:
 	{
 		Data.Append(InOther.Data);
 	}
-	void Append(const TArray<FVector>& InNormals, const TArray<FRuntimeMeshTangent>& InTangents)
+	void Append(const TArray<FVector3f>& InNormals, const TArray<FRuntimeMeshTangent>& InTangents)
 	{
 		int32 MaxCount = FMath::Max(InNormals.Num(), InTangents.Num());
 
@@ -203,8 +203,8 @@ public:
 			const int32 NormalIndex = FMath::Min(Index, InNormals.Num());
 			const int32 TangentIndex = FMath::Min(Index, InTangents.Num());
 
-			FVector4 Normal;
-			FVector Tangent;
+			FVector4f Normal;
+			FVector3f Tangent;
 
 			if (InNormals.IsValidIndex(NormalIndex))
 			{
@@ -212,7 +212,7 @@ public:
 			}
 			else
 			{
-				Normal = FVector(0, 0, 1);
+				Normal = FVector3f(0, 0, 1);
 			}
 
 			if (InTangents.IsValidIndex(TangentIndex))
@@ -222,7 +222,7 @@ public:
 			}
 			else
 			{
-				Tangent = FVector(1, 0, 0);
+				Tangent = FVector3f(1, 0, 0);
 				Normal.W = 1.0f;
 			}
 
@@ -230,7 +230,7 @@ public:
 		}
 	}
 		
-	void SetNormal(int32 Index, const FVector& NewNormal)
+	void SetNormal(int32 Index, const FVector3f& NewNormal)
 	{
 		const int32 EntryIndex = Index * 2 + 1;
 		if (bIsHighPrecision)
@@ -242,7 +242,7 @@ public:
 			*((FPackedNormal*)&Data[EntryIndex * sizeof(FPackedNormal)]) = FPackedNormal(NewNormal);
 		}
 	}
-	void SetTangent(int32 Index, const FVector& NewTangent)
+	void SetTangent(int32 Index, const FVector3f& NewTangent)
 	{
 		const int32 EntryIndex = Index * 2;
 		if (bIsHighPrecision)
@@ -254,63 +254,63 @@ public:
 			*((FPackedNormal*)&Data[EntryIndex * sizeof(FPackedNormal)]) = FPackedNormal(NewTangent);
 		}
 	}
-	void SetTangents(int32 Index, const FVector& InTangentX, const FVector& InTangentY, const FVector& InTangentZ)
+	void SetTangents(int32 Index, const FVector3f& InTangentX, const FVector3f& InTangentY, const FVector3f& InTangentZ)
 	{
 		const int32 EntryIndex = Index * 2;
 		if (bIsHighPrecision)
 		{
 			*((FPackedRGBA16N*)&Data[EntryIndex * sizeof(FPackedRGBA16N)]) = FPackedRGBA16N(InTangentX);
-			*((FPackedRGBA16N*)&Data[(EntryIndex + 1) * sizeof(FPackedRGBA16N)]) = FPackedRGBA16N(FVector4(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
+			*((FPackedRGBA16N*)&Data[(EntryIndex + 1) * sizeof(FPackedRGBA16N)]) = FPackedRGBA16N(FVector4f(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
 		}
 		else
 		{
 			*((FPackedNormal*)&Data[EntryIndex * sizeof(FPackedNormal)]) = FPackedNormal(InTangentX);
-			*((FPackedNormal*)&Data[(EntryIndex + 1) * sizeof(FPackedNormal)]) = FPackedNormal(FVector4(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
+			*((FPackedNormal*)&Data[(EntryIndex + 1) * sizeof(FPackedNormal)]) = FPackedNormal(FVector4f(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
 		}
 	}
 
-	FVector GetNormal(int32 Index) const
+	FVector3f GetNormal(int32 Index) const
 	{
 		const int32 EntryIndex = Index * 2 + 1;
 		if (bIsHighPrecision)
 		{
-			return (*((FPackedRGBA16N*)&Data[EntryIndex * sizeof(FPackedRGBA16N)])).ToFVector();
+			return (*((FPackedRGBA16N*)&Data[EntryIndex * sizeof(FPackedRGBA16N)])).ToFVector3f();
 		}
 		else
 		{
-			return (*((FPackedNormal*)&Data[EntryIndex * sizeof(FPackedNormal)])).ToFVector();
+			return (*((FPackedNormal*)&Data[EntryIndex * sizeof(FPackedNormal)])).ToFVector3f();
 		}
 	}
-	FVector GetTangent(int32 Index) const
+	FVector3f GetTangent(int32 Index) const
 	{
 		const int32 EntryIndex = Index * 2;
 		if (bIsHighPrecision)
 		{
-			return (*((FPackedRGBA16N*)&Data[EntryIndex * sizeof(FPackedRGBA16N)])).ToFVector();
+			return (*((FPackedRGBA16N*)&Data[EntryIndex * sizeof(FPackedRGBA16N)])).ToFVector3f();
 		}
 		else
 		{
-			return (*((FPackedNormal*)&Data[EntryIndex * sizeof(FPackedNormal)])).ToFVector();
+			return (*((FPackedNormal*)&Data[EntryIndex * sizeof(FPackedNormal)])).ToFVector3f();
 		}
 	}
-	void GetTangents(int32 Index, FVector& OutTangentX, FVector& OutTangentY, FVector& OutTangentZ) const
+	void GetTangents(int32 Index, FVector3f& OutTangentX, FVector3f& OutTangentY, FVector3f& OutTangentZ) const
 	{
 		const int32 EntryIndex = Index * 2;
 		if (bIsHighPrecision)
 		{
 			FPackedRGBA16N TempTangentX = *((FPackedRGBA16N*)&Data[EntryIndex * sizeof(FPackedRGBA16N)]);
 			FPackedRGBA16N TempTangentZ = *((FPackedRGBA16N*)&Data[(EntryIndex + 1) * sizeof(FPackedRGBA16N)]);
-			OutTangentX = TempTangentX.ToFVector();
-			OutTangentY = GenerateYAxis(TempTangentX, TempTangentZ);
-			OutTangentZ = TempTangentZ.ToFVector();
+			OutTangentX = TempTangentX.ToFVector3f();
+			OutTangentY = (FVector3f)GenerateYAxis(TempTangentX, TempTangentZ);
+			OutTangentZ = TempTangentZ.ToFVector3f();
 		}
 		else
 		{
 			FPackedNormal TempTangentX = *((FPackedNormal*)&Data[EntryIndex * sizeof(FPackedNormal)]);
 			FPackedNormal TempTangentZ = *((FPackedNormal*)&Data[(EntryIndex + 1) * sizeof(FPackedNormal)]);
-			OutTangentX = TempTangentX.ToFVector();
-			OutTangentY = GenerateYAxis(TempTangentX, TempTangentZ);
-			OutTangentZ = TempTangentZ.ToFVector();
+			OutTangentX = TempTangentX.ToFVector3f();
+			OutTangentY = (FVector3f)GenerateYAxis(TempTangentX, TempTangentZ);
+			OutTangentZ = TempTangentZ.ToFVector3f();
 		}
 	}
 

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshRenderable.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshRenderable.h
@@ -316,7 +316,7 @@ public:
 
 	const uint8* GetData() const { return Data.GetData(); }
 	TArray<uint8>&& TakeData()&& { return MoveTemp(Data); }
-// 	const TArray<TArray<FVector2D>> GetCopy() const
+// 	const TArray<TArray<FVector2f>> GetCopy() const
 // 	{
 // 		TArray<FVector> OutData;
 // 		OutData.SetNum(Num());
@@ -362,7 +362,7 @@ public:
 		return ChannelCount;
 	}
 
-	FORCEINLINE int32 GetElementSize() const { return (bIsHighPrecision ? sizeof(FVector2D) : sizeof(FVector2DHalf)); } //size in bytes
+	FORCEINLINE int32 GetElementSize() const { return (bIsHighPrecision ? sizeof(FVector2f) : sizeof(FVector2DHalf)); } //size in bytes
 	FORCEINLINE int32 GetStride() const { return GetElementSize() * ChannelCount; } //num of bytes of UV per vertex in data
 
 	FORCEINLINE int32 Num() const
@@ -392,7 +392,7 @@ public:
 	If you skip any it'll crash UE
 	(if you're here because it crashed, told you !)
 	*/
-	int32 Add(const FVector2D& InTexCoord, int32 ChannelId = 0)
+	int32 Add(const FVector2f& InTexCoord, int32 ChannelId = 0)
 	{
 		int32 Index = Data.Num();
 		checkf((Index / GetElementSize()) % ChannelCount == ChannelId, TEXT("[FRuntimeMeshVertexTexCoordStream::Add] UVs have been added out of order, aborting..."));
@@ -400,8 +400,8 @@ public:
 
 		if (bIsHighPrecision)
 		{
-			static const int32 ElementSize = sizeof(FVector2D);
-			*((FVector2D*)&Data[Index]) = InTexCoord;
+			static const int32 ElementSize = sizeof(FVector2f);
+			*((FVector2f*)&Data[Index]) = InTexCoord;
 		}
 		else
 		{
@@ -416,7 +416,7 @@ public:
 	Current UV Array must end with the last UV (meaning the previous vert must have had all of it's UVs registered)
 	Given array must be of the same length as the number of UV channels
 	*/
-	int32 Add(const TArray<FVector2D>& InTexCoords)
+	int32 Add(const TArray<FVector2f>& InTexCoords)
 	{
 		const int oldNum = Data.Num();
 		const int32 Index = Num();
@@ -427,11 +427,11 @@ public:
 
 		if (bIsHighPrecision)
 		{
-			static const int32 ElementSize = sizeof(FVector2D);
+			static const int32 ElementSize = sizeof(FVector2f);
 
 			for (int32 ChannelId = 0; ChannelId < ChannelCount; ChannelId++)
 			{
-				*((FVector2D*)&Data[(Index * Stride) + (ChannelId * ElementSize)]) = InTexCoords[ChannelId];
+				*((FVector2f*)&Data[(Index * Stride) + (ChannelId * ElementSize)]) = InTexCoords[ChannelId];
 			}
 		}
 		else
@@ -455,7 +455,7 @@ public:
 			bIsHighPrecision ? TEXT("HighPrecision") : TEXT("LowPrecision"));
 		Data.Append(InOther.Data);
 	}
-	void FillIn(int32 StartIndex, const TArray<FVector2D>& InChannelData, int32 ChannelId = 0)
+	void FillIn(int32 StartIndex, const TArray<FVector2f>& InChannelData, int32 ChannelId = 0)
 	{
 		if (Num() < (StartIndex + InChannelData.Num()))
 		{
@@ -468,12 +468,12 @@ public:
 		}
 	}
 
-	void SetTexCoord(int32 Index, const FVector2D& NewTexCoord, int32 ChannelId = 0)
+	void SetTexCoord(int32 Index, const FVector2f& NewTexCoord, int32 ChannelId = 0)
 	{
 		if (bIsHighPrecision)
 		{
-			static const int32 ElementSize = sizeof(FVector2D);
-			*((FVector2D*)&Data[(Index * ElementSize * ChannelCount) + (ChannelId * ElementSize)]) = NewTexCoord;
+			static const int32 ElementSize = sizeof(FVector2f);
+			*((FVector2f*)&Data[(Index * ElementSize * ChannelCount) + (ChannelId * ElementSize)]) = NewTexCoord;
 		}
 		else
 		{
@@ -481,12 +481,12 @@ public:
 			*((FVector2DHalf*)&Data[(Index * ElementSize * ChannelCount) + (ChannelId * ElementSize)]) = NewTexCoord;
 		}
 	}
-	const FVector2D GetTexCoord(int32 Index, int32 ChannelId = 0) const
+	const FVector2f GetTexCoord(int32 Index, int32 ChannelId = 0) const
 	{
 		if (bIsHighPrecision)
 		{
-			static const int32 ElementSize = sizeof(FVector2D);
-			return *((FVector2D*)&Data[(Index * ElementSize * ChannelCount) + (ChannelId * ElementSize)]);
+			static const int32 ElementSize = sizeof(FVector2f);
+			return *((FVector2f*)&Data[(Index * ElementSize * ChannelCount) + (ChannelId * ElementSize)]);
 		}
 		else
 		{
@@ -497,9 +497,9 @@ public:
 
 	const uint8* GetData() const { return Data.GetData(); }
 	TArray<uint8>&& TakeData()&& { return MoveTemp(Data); }
-	// 	const TArray<TArray<FVector2D>> GetCopy() const
+	// 	const TArray<TArray<FVector2f>> GetCopy() const
 	// 	{
-	// 		TArray<FVector> OutData;
+	// 		TArray<FVector3f> OutData;
 	// 		OutData.SetNum(Num());
 	// 		FMemory::Memcpy(OutData.GetData(), Data.GetData(), Data.Num());
 	// 		return OutData;
@@ -590,9 +590,9 @@ public:
 
 	const uint8* GetData() const { return Data.GetData(); }
 	TArray<uint8>&& TakeData()&& { return MoveTemp(Data); }
-	// 	const TArray<TArray<FVector2D>> GetCopy() const
+	// 	const TArray<TArray<FVector2f>> GetCopy() const
 	// 	{
-	// 		TArray<FVector> OutData;
+	// 		TArray<FVector3f> OutData;
 	// 		OutData.SetNum(Num());
 	// 		FMemory::Memcpy(OutData.GetData(), Data.GetData(), Data.Num());
 	// 		return OutData;
@@ -761,9 +761,9 @@ public:
 
 	const uint8* GetData() const { return Data.GetData(); }
 	TArray<uint8>&& TakeData()&& { return MoveTemp(Data); }
-	// 	const TArray<TArray<FVector2D>> GetCopy() const
+	// 	const TArray<TArray<FVector2f>> GetCopy() const
 	// 	{
-	// 		TArray<FVector> OutData;
+	// 		TArray<FVector3f> OutData;
 	// 		OutData.SetNum(Num());
 	// 		FMemory::Memcpy(OutData.GetData(), Data.GetData(), Data.Num());
 	// 		return OutData;
@@ -1137,70 +1137,70 @@ namespace __RuntimeMeshNatVisRenderableTypes
 
 	struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshTexCoordHighPrecision1
 	{
-		FVector2D UV0;
+		FVector2f UV0;
 	};
 
 	struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshTexCoordHighPrecision2
 	{
-		FVector2D UV0;
-		FVector2D UV1;
+		FVector2f UV0;
+		FVector2f UV1;
 	};
 
 	struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshTexCoordHighPrecision3
 	{
-		FVector2D UV0;
-		FVector2D UV1;
-		FVector2D UV2;
+		FVector2f UV0;
+		FVector2f UV1;
+		FVector2f UV2;
 	};
 
 	struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshTexCoordHighPrecision4
 	{
-		FVector2D UV0;
-		FVector2D UV1;
-		FVector2D UV2;
-		FVector2D UV3;
+		FVector2f UV0;
+		FVector2f UV1;
+		FVector2f UV2;
+		FVector2f UV3;
 	};
 
 	struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshTexCoordHighPrecision5
 	{
-		FVector2D UV0;
-		FVector2D UV1;
-		FVector2D UV2;
-		FVector2D UV3;
-		FVector2D UV4;
+		FVector2f UV0;
+		FVector2f UV1;
+		FVector2f UV2;
+		FVector2f UV3;
+		FVector2f UV4;
 	};
 
 	struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshTexCoordHighPrecision6
 	{
-		FVector2D UV0;
-		FVector2D UV1;
-		FVector2D UV2;
-		FVector2D UV3;
-		FVector2D UV4;
-		FVector2D UV5;
+		FVector2f UV0;
+		FVector2f UV1;
+		FVector2f UV2;
+		FVector2f UV3;
+		FVector2f UV4;
+		FVector2f UV5;
 	};
 
 	struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshTexCoordHighPrecision7
 	{
-		FVector2D UV0;
-		FVector2D UV1;
-		FVector2D UV2;
-		FVector2D UV3;
-		FVector2D UV4;
-		FVector2D UV5;
-		FVector2D UV6;
+		FVector2f UV0;
+		FVector2f UV1;
+		FVector2f UV2;
+		FVector2f UV3;
+		FVector2f UV4;
+		FVector2f UV5;
+		FVector2f UV6;
 	};
 
 	struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshTexCoordHighPrecision8
 	{
-		FVector2D UV0;
-		FVector2D UV1;
-		FVector2D UV2;
-		FVector2D UV3;
-		FVector2D UV4;
-		FVector2D UV5;
-		FVector2D UV6;
-		FVector2D UV7;
+		FVector2f UV0;
+		FVector2f UV1;
+		FVector2f UV2;
+		FVector2f UV3;
+		FVector2f UV4;
+		FVector2f UV5;
+		FVector2f UV6;
+		FVector2f UV7;
 	};
 
 }

--- a/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentDetails.cpp
+++ b/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentDetails.cpp
@@ -152,7 +152,7 @@ FReply FRuntimeMeshComponentDetails::ClickedOnConvertToStaticMesh()
 			}
 
 			// Create the package to save the static mesh
-			UPackage* Package = CreatePackage(NULL, *UserPackageName);
+			UPackage* Package = CreatePackage(*UserPackageName);
 			check(Package);
 
 			// Create StaticMesh object
@@ -220,7 +220,7 @@ FReply FRuntimeMeshComponentDetails::ClickedOnConvertToStaticMesh()
 							int32 VertexIndex = MeshData.Triangles.GetVertexIndex(Index);
 							RawMesh.WedgeIndices.Add(VertexIndex + VertexBase);
 
-							FVector TangentX, TangentY, TangentZ;
+							FVector3f TangentX, TangentY, TangentZ;
 							MeshData.Tangents.GetTangents(VertexIndex, TangentX, TangentY, TangentZ);
 							RawMesh.WedgeTangentX.Add(TangentX);
 							RawMesh.WedgeTangentY.Add(TangentY);
@@ -228,7 +228,7 @@ FReply FRuntimeMeshComponentDetails::ClickedOnConvertToStaticMesh()
 
 							for (int32 UVIndex = 0; UVIndex < Section.NumTexCoords; UVIndex++)
 							{
-								RawMesh.WedgeTexCoords[UVIndex].Add(MeshData.TexCoords.GetTexCoord(VertexIndex, UVIndex));
+								RawMesh.WedgeTexCoords[UVIndex].Add((FVector2f)MeshData.TexCoords.GetTexCoord(VertexIndex, UVIndex));
 							}
 
 							RawMesh.WedgeColors.Add(MeshData.Colors.GetColor(VertexIndex));


### PR DESCRIPTION
Restores functionality after Large World Coordinates changed `FVector` and `FVector2D` to double precision. Specifying `FVector3f` ensures single precision.

Due to a collision class still using double precision `FVector`, copying and conversions were required to pass mesh data.

`UFUNCTION`s do not accept `TArray<FVector3f>` or `TArray<FVector2f>` as input, so copying and conversions were added for these functions in particular.

It appears some UE mesh-related classes changed name as well.