### PR TITLE
Supporting UE 5.0.0: Adding explicit conversions.

### DIFF
--- a/Source/RuntimeMeshComponent/Private/Modifiers/RuntimeMeshModifierAdjacency.cpp
+++ b/Source/RuntimeMeshComponent/Private/Modifiers/RuntimeMeshModifierAdjacency.cpp
@@ -55,14 +55,14 @@ void URuntimeMeshModifierAdjacency::CalculateTessellationIndices(FRuntimeMeshRen
 
 void URuntimeMeshModifierAdjacency::AddIfLeastUV(PositionDictionary& PosDict, const Vertex& Vert, uint32 Index)
 {
-	auto* Pos = PosDict.Find(Vert.Position);
+	auto* Pos = PosDict.Find(FVector(Vert.Position));
 	if (Pos == nullptr)
 	{
-		PosDict.Add(Vert.Position, Corner(Index, Vert.TexCoord));
+		PosDict.Add(FVector(Vert.Position), Corner(Index, Vert.TexCoord));
 	}
 	else if (Vert.TexCoord < Pos->TexCoord)
 	{
-		PosDict[Vert.Position] = Corner(Index, Vert.TexCoord);
+		PosDict[FVector(Vert.Position)] = Corner(Index, Vert.TexCoord);
 	}
 }
 
@@ -110,7 +110,7 @@ void URuntimeMeshModifierAdjacency::ReplacePlaceholderIndices(FRuntimeMeshRender
 		// Deal with dominant positions.
 		for (uint32 V = 0; V < VerticesPerTriangle; V++)
 		{
-			Corner* Corn = PosDict.Find(Tri.GetEdge(V).GetVertex(0).Position);
+			Corner* Corn = PosDict.Find(FVector(Tri.GetEdge(V).GetVertex(0).Position));
 			if (Corn != nullptr)
 			{
 				MeshData.AdjacencyTriangles.SetVertexIndex(StartOutIndex + 9 + V, Corn->Index);

--- a/Source/RuntimeMeshComponent/Private/Modifiers/RuntimeMeshModifierNormals.cpp
+++ b/Source/RuntimeMeshComponent/Private/Modifiers/RuntimeMeshModifierNormals.cpp
@@ -114,20 +114,19 @@ void URuntimeMeshModifierNormals::CalculateNormalsTangents(FRuntimeMeshRenderabl
 			// 			FaceTangentY[TriIdx] = FVector3f((S1 * X2 - S2 * X1) * R, (S1 * Y2 - S2 * Y1) * R,
 			// 				(S1 * Z2 - S2 * Z1) * R);
 
-
-
+			
 			FMatrix44f	ParameterToLocal(
-				FPlane(P[1].X - P[0].X, P[1].Y - P[0].Y, P[1].Z - P[0].Z, 0),
-				FPlane(P[2].X - P[0].X, P[2].Y - P[0].Y, P[2].Z - P[0].Z, 0),
-				FPlane(P[0].X, P[0].Y, P[0].Z, 0),
-				FPlane(0, 0, 0, 1)
+				FPlane4f(P[1].X - P[0].X, P[1].Y - P[0].Y, P[1].Z - P[0].Z, 0),
+				FPlane4f(P[2].X - P[0].X, P[2].Y - P[0].Y, P[2].Z - P[0].Z, 0),
+				FPlane4f(P[0].X, P[0].Y, P[0].Z, 0),
+				FPlane4f(0, 0, 0, 1)
 				);
 
 			FMatrix44f ParameterToTexture(
-				FPlane(T2.X - T1.X, T2.Y - T1.Y, 0, 0),
-				FPlane(T3.X - T1.X, T3.Y - T1.Y, 0, 0),
-				FPlane(T1.X, T1.Y, 1, 0),
-				FPlane(0, 0, 0, 1)
+				FPlane4f(T2.X - T1.X, T2.Y - T1.Y, 0, 0),
+				FPlane4f(T3.X - T1.X, T3.Y - T1.Y, 0, 0),
+				FPlane4f(T1.X, T1.Y, 1, 0),
+				FPlane4f(0, 0, 0, 1)
 				);
 
 			// Use InverseSlow to catch singular matrices.  Inverse can miss this sometimes.
@@ -208,7 +207,7 @@ TMultiMap<uint32, uint32> URuntimeMeshModifierNormals::FindDuplicateVerticesMap(
 	VertexSorter.Empty(NumVertices);
 	for (int32 Index = 0; Index < NumVertices; Index++)
 	{
-		new (VertexSorter)FRuntimeMeshVertexSortingElement(Index, PositionStream.GetPosition(Index));
+		new (VertexSorter)FRuntimeMeshVertexSortingElement(Index, FVector(PositionStream.GetPosition(Index)));
 	}
 
 	// Sort the list

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderBox.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderBox.cpp
@@ -81,8 +81,8 @@ bool URuntimeMeshProviderBox::GetSectionMeshForLOD(int32 LODIndex, int32 Section
 
 	auto AddVertex = [&](const FVector& InPosition, const FVector& InTangentX, const FVector& InTangentZ, const FVector2f& InTexCoord)
 	{
-		MeshData.Positions.Add(InPosition);
-		MeshData.Tangents.Add(InTangentZ, InTangentX);
+		MeshData.Positions.Add(FVector3f(InPosition));
+		MeshData.Tangents.Add(FVector3f(InTangentZ), FVector3f(InTangentX));
 		MeshData.Colors.Add(FColor::White);
 		MeshData.TexCoords.Add(InTexCoord);
 	};
@@ -180,15 +180,15 @@ bool URuntimeMeshProviderBox::GetCollisionMesh(FRuntimeMeshCollisionData& Collis
 	FVector BoxRadiusTemp = BoxRadius;
 
 	// Generate verts
-	CollisionVertices.Add(FVector(-BoxRadiusTemp.X, BoxRadiusTemp.Y, BoxRadiusTemp.Z));
-	CollisionVertices.Add(FVector(BoxRadiusTemp.X, BoxRadiusTemp.Y, BoxRadiusTemp.Z));
-	CollisionVertices.Add(FVector(BoxRadiusTemp.X, -BoxRadiusTemp.Y, BoxRadiusTemp.Z));
-	CollisionVertices.Add(FVector(-BoxRadiusTemp.X, -BoxRadiusTemp.Y, BoxRadiusTemp.Z));
+	CollisionVertices.Add(FVector3f(-BoxRadiusTemp.X, BoxRadiusTemp.Y, BoxRadiusTemp.Z));
+	CollisionVertices.Add(FVector3f(BoxRadiusTemp.X, BoxRadiusTemp.Y, BoxRadiusTemp.Z));
+	CollisionVertices.Add(FVector3f(BoxRadiusTemp.X, -BoxRadiusTemp.Y, BoxRadiusTemp.Z));
+	CollisionVertices.Add(FVector3f(-BoxRadiusTemp.X, -BoxRadiusTemp.Y, BoxRadiusTemp.Z));
 
-	CollisionVertices.Add(FVector(-BoxRadiusTemp.X, BoxRadiusTemp.Y, -BoxRadiusTemp.Z));
-	CollisionVertices.Add(FVector(BoxRadiusTemp.X, BoxRadiusTemp.Y, -BoxRadiusTemp.Z));
-	CollisionVertices.Add(FVector(BoxRadiusTemp.X, -BoxRadiusTemp.Y, -BoxRadiusTemp.Z));
-	CollisionVertices.Add(FVector(-BoxRadiusTemp.X, -BoxRadiusTemp.Y, -BoxRadiusTemp.Z));
+	CollisionVertices.Add(FVector3f(-BoxRadiusTemp.X, BoxRadiusTemp.Y, -BoxRadiusTemp.Z));
+	CollisionVertices.Add(FVector3f(BoxRadiusTemp.X, BoxRadiusTemp.Y, -BoxRadiusTemp.Z));
+	CollisionVertices.Add(FVector3f(BoxRadiusTemp.X, -BoxRadiusTemp.Y, -BoxRadiusTemp.Z));
+	CollisionVertices.Add(FVector3f(-BoxRadiusTemp.X, -BoxRadiusTemp.Y, -BoxRadiusTemp.Z));
 
 	// Pos Z
 	CollisionTriangles.Add(0, 1, 3);

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderPlane.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderPlane.cpp
@@ -65,8 +65,8 @@ bool URuntimeMeshProviderPlane::GetSectionMeshForLOD(int32 LODIndex, int32 Secti
 			FVector Location = LocationA + ABDirection * ABIndex + ACDirection * ACIndex;
 			FVector2f TexCoord = FVector2f((float)ABIndex / (float)(NumVertsAB - 1), (float)ACIndex / (float)(NumVertsAC - 1));
 			//UE_LOG(LogTemp, Log, TEXT("TexCoord for vertex %i:%i : %s"), ABIndex, ACIndex, *TexCoord.ToString());
-			MeshData.Positions.Add(Location);
-			MeshData.Tangents.Add(Normal, Tangent);
+			MeshData.Positions.Add(FVector3f(Location));
+			MeshData.Tangents.Add(FVector3f(Normal), FVector3f(Tangent));
 			MeshData.Colors.Add(Color);
 			MeshData.TexCoords.Add(TexCoord);
 			if (ABIndex != NumVertsAB - 1 && ACIndex != NumVertsAC - 1)

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
@@ -773,7 +773,7 @@ void URuntimeMeshProviderStatic::UpdateBounds()
 
 FBoxSphereBounds URuntimeMeshProviderStatic::GetBoundsFromMeshData(const FRuntimeMeshRenderableMeshData& MeshData)
 {
-	return FBoxSphereBounds(MeshData.Positions.GetBounds());
+	return FBoxSphereBounds(FBox(MeshData.Positions.GetBounds()));
 }
 
 void URuntimeMeshProviderStatic::UpdateSectionInternal(int32 LODIndex, int32 SectionId, FRuntimeMeshRenderableMeshData&& SectionData, FBoxSphereBounds KnownBounds)

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshBlueprintFunctions.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshBlueprintFunctions.cpp
@@ -69,7 +69,7 @@ void URuntimeMeshBlueprintFunctions::EmptyPositions(FRuntimeMeshVertexPositionSt
 void URuntimeMeshBlueprintFunctions::AddPosition(FRuntimeMeshVertexPositionStream& Stream, FRuntimeMeshVertexPositionStream& OutStream, FVector InPosition, int32& OutIndex)
 {
 	OutStream = Stream;
-	OutIndex = Stream.Add(InPosition);
+	OutIndex = Stream.Add(FVector3f(InPosition));
 }
 
 void URuntimeMeshBlueprintFunctions::AppendPositions(FRuntimeMeshVertexPositionStream& Stream, FRuntimeMeshVertexPositionStream& OutStream, const FRuntimeMeshVertexPositionStream& InOther)
@@ -81,19 +81,19 @@ void URuntimeMeshBlueprintFunctions::AppendPositions(FRuntimeMeshVertexPositionS
 void URuntimeMeshBlueprintFunctions::GetPosition(FRuntimeMeshVertexPositionStream& Stream, FRuntimeMeshVertexPositionStream& OutStream, int32 Index, FVector& OutPosition)
 {
 	OutStream = Stream;
-	OutPosition = Stream.GetPosition(Index);
+	OutPosition = FVector(Stream.GetPosition(Index));
 }
 
 void URuntimeMeshBlueprintFunctions::SetPosition(FRuntimeMeshVertexPositionStream& Stream, FRuntimeMeshVertexPositionStream& OutStream, int32 Index, FVector NewPosition)
 {
 	OutStream = Stream;
-	Stream.SetPosition(Index, NewPosition);
+	Stream.SetPosition(Index, FVector3f(NewPosition));
 }
 
 void URuntimeMeshBlueprintFunctions::GetBounds(FRuntimeMeshVertexPositionStream& Stream, FRuntimeMeshVertexPositionStream& OutStream, FBox& OutBounds)
 {
 	OutStream = Stream;
-	OutBounds = Stream.GetBounds();
+	OutBounds = FBox(Stream.GetBounds());
 }
 
 
@@ -120,13 +120,13 @@ void URuntimeMeshBlueprintFunctions::EmptyTangents(FRuntimeMeshVertexTangentStre
 void URuntimeMeshBlueprintFunctions::AddNormalAndTangent(FRuntimeMeshVertexTangentStream& Stream, FRuntimeMeshVertexTangentStream& OutStream, FVector InNormal, FVector InTangent, int32& OutIndex)
 {
 	OutStream = Stream;
-	OutIndex = Stream.Add(InNormal, InTangent);
+	OutIndex = Stream.Add(FVector3f(InNormal), FVector3f(InTangent));
 }
 
 void URuntimeMeshBlueprintFunctions::AddTangents(FRuntimeMeshVertexTangentStream& Stream, FRuntimeMeshVertexTangentStream& OutStream, FVector InTangentX, FVector InTangentY, FVector InTangentZ, int32& OutIndex)
 {
 	OutStream = Stream;
-	OutIndex = Stream.Add(InTangentX, InTangentY, InTangentZ);
+	OutIndex = Stream.Add(FVector3f(InTangentX), FVector3f(InTangentY), FVector3f(InTangentZ));
 }
 
 void URuntimeMeshBlueprintFunctions::AppendTangents(FRuntimeMeshVertexTangentStream& Stream, FRuntimeMeshVertexTangentStream& OutStream, const FRuntimeMeshVertexTangentStream& InOther)
@@ -138,25 +138,25 @@ void URuntimeMeshBlueprintFunctions::AppendTangents(FRuntimeMeshVertexTangentStr
 void URuntimeMeshBlueprintFunctions::GetNormal(FRuntimeMeshVertexTangentStream& Stream, FRuntimeMeshVertexTangentStream& OutStream, int32 Index, FVector& OutNormal)
 {
 	OutStream = Stream;
-	OutNormal = Stream.GetNormal(Index);
+	OutNormal = FVector(Stream.GetNormal(Index));
 }
 
 void URuntimeMeshBlueprintFunctions::SetNormal(FRuntimeMeshVertexTangentStream& Stream, FRuntimeMeshVertexTangentStream& OutStream, int32 Index, FVector NewNormal)
 {
 	OutStream = Stream;
-	Stream.SetNormal(Index, NewNormal);
+	Stream.SetNormal(Index, FVector3f(NewNormal));
 }
 
 void URuntimeMeshBlueprintFunctions::GetTangent(FRuntimeMeshVertexTangentStream& Stream, FRuntimeMeshVertexTangentStream& OutStream, int32 Index, FVector& OutTangent)
 {
 	OutStream = Stream;
-	OutTangent = Stream.GetTangent(Index);
+	OutTangent = FVector(Stream.GetTangent(Index));
 }
 
 void URuntimeMeshBlueprintFunctions::SetTangent(FRuntimeMeshVertexTangentStream& Stream, FRuntimeMeshVertexTangentStream& OutStream, int32 Index, FVector NewTangent)
 {
 	OutStream = Stream;
-	Stream.SetTangent(Index, NewTangent);
+	Stream.SetTangent(Index, FVector3f(NewTangent));
 }
 
 void URuntimeMeshBlueprintFunctions::GetTangents(FRuntimeMeshVertexTangentStream& Stream, FRuntimeMeshVertexTangentStream& OutStream, int32 Index, FVector& OutTangentX, FVector& OutTangentY, FVector& OutTangentZ)
@@ -164,15 +164,15 @@ void URuntimeMeshBlueprintFunctions::GetTangents(FRuntimeMeshVertexTangentStream
 	OutStream = Stream;
 	FVector3f tangentX, tangentY, tangentZ;
 	Stream.GetTangents(Index, tangentX, tangentY, tangentZ);
-	OutTangentX = (FVector)tangentX;
-	OutTangentY = (FVector)tangentY;
-	OutTangentZ = (FVector)tangentZ;
+	OutTangentX = FVector(tangentX);
+	OutTangentY = FVector(tangentY);
+	OutTangentZ = FVector(tangentZ);
 }
 
 void URuntimeMeshBlueprintFunctions::SetTangents(FRuntimeMeshVertexTangentStream& Stream, FRuntimeMeshVertexTangentStream& OutStream, int32 Index, FVector InTangentX, FVector InTangentY, FVector InTangentZ)
 {
 	OutStream = Stream;
-	Stream.SetTangents(Index, InTangentX, InTangentY, InTangentZ);
+	Stream.SetTangents(Index, FVector3f(InTangentX), FVector3f(InTangentY), FVector3f(InTangentZ));
 }
 
 
@@ -379,19 +379,19 @@ void URuntimeMeshBlueprintFunctions::EmptyCollisionVertices(FRuntimeMeshCollisio
 void URuntimeMeshBlueprintFunctions::AddCollisionVertex(FRuntimeMeshCollisionVertexStream& Stream, FRuntimeMeshCollisionVertexStream& OutStream, FVector InVertex, int32& OutIndex)
 {
 	OutStream = Stream;
-	OutIndex = Stream.Add(InVertex);
+	OutIndex = Stream.Add(FVector3f(InVertex));
 }
 
 void URuntimeMeshBlueprintFunctions::GetCollisionVertex(FRuntimeMeshCollisionVertexStream& Stream, FRuntimeMeshCollisionVertexStream& OutStream, int32 Index, FVector& OutVertex)
 {
 	OutStream = Stream;
-	OutVertex = Stream.GetPosition(Index);
+	OutVertex = FVector(Stream.GetPosition(Index));
 }
 
 void URuntimeMeshBlueprintFunctions::SetCollisionVertex(FRuntimeMeshCollisionVertexStream& Stream, FRuntimeMeshCollisionVertexStream& OutStream, int32 Index, FVector NewVertex)
 {
 	OutStream = Stream;
-	Stream.SetPosition(Index, NewVertex);
+	Stream.SetPosition(Index, FVector3f(NewVertex));
 }
 
 

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshSlicer.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshSlicer.cpp
@@ -153,7 +153,7 @@ void Transform2DPolygonTo3D(const FUtilPoly2D& InPoly, const FMatrix& InMatrix, 
 		const FUtilVertex2D& InVertex = InPoly.Verts[VertexIndex];
 
 		OutMeshData.Positions.Add((FVector3f)FVector3d(InMatrix.TransformPosition(FVector(InVertex.Pos.X, InVertex.Pos.Y, 0.f))));
-		OutMeshData.Tangents.Add(TangentX, TangentY, TangentZ);
+		OutMeshData.Tangents.Add(FVector3f(TangentX), FVector3f(TangentY), FVector3f(TangentZ));
 		OutMeshData.Colors.Add(InVertex.Color);
 		OutMeshData.TexCoords.Add(FVector2f(InVertex.UV));
 	}
@@ -195,9 +195,9 @@ bool TriangulatePoly(FRuntimeMeshRenderableMeshData& MeshData, int32 VertBase, c
 			const int32 BIndex = EarVertexIndex;
 			const int32 CIndex = (EarVertexIndex + 1) % VertIndices.Num();
 
-			const FVector AVertPos = MeshData.Positions.GetPosition(VertIndices[AIndex]);
-			const FVector BVertPos = MeshData.Positions.GetPosition(VertIndices[BIndex]);
-			const FVector CVertPos = MeshData.Positions.GetPosition(VertIndices[CIndex]);
+			const FVector AVertPos = FVector(MeshData.Positions.GetPosition(VertIndices[AIndex]));
+			const FVector BVertPos = FVector(MeshData.Positions.GetPosition(VertIndices[BIndex]));
+			const FVector CVertPos = FVector(MeshData.Positions.GetPosition(VertIndices[CIndex]));
 
 			// Check that this vertex is convex (cross product must be positive)
 			const FVector ABEdge = BVertPos - AVertPos;
@@ -212,12 +212,12 @@ bool TriangulatePoly(FRuntimeMeshRenderableMeshData& MeshData, int32 VertBase, c
 			// Look through all verts before this in array to see if any are inside triangle
 			for (int32 VertexIndex = 0; VertexIndex < VertIndices.Num(); VertexIndex++)
 			{
-				const FVector TestVertPos = MeshData.Positions.GetPosition(VertIndices[VertexIndex]);
+				const FVector TestVertPos = FVector(MeshData.Positions.GetPosition(VertIndices[VertexIndex]));
 
 				if (VertexIndex != AIndex &&
 					VertexIndex != BIndex &&
 					VertexIndex != CIndex &&
-					FGeomTools::PointInTriangle(AVertPos, BVertPos, CVertPos, TestVertPos))
+					FGeomTools::PointInTriangle(FVector3f(AVertPos), FVector3f(BVertPos), FVector3f(CVertPos), FVector3f(TestVertPos)))
 				{
 					bFoundVertInside = true;
 					break;
@@ -514,7 +514,7 @@ void URuntimeMeshSlicer::SliceRuntimeMesh(URuntimeMeshComponent* InRuntimeMesh, 
 			// Build vertex buffer 
 			for (int32 BaseVertIndex = 0; BaseVertIndex < NumBaseVerts; BaseVertIndex++)
 			{
-				FVector Position = SourceSection.Positions.GetPosition(BaseVertIndex);
+				FVector Position = FVector(SourceSection.Positions.GetPosition(BaseVertIndex));
 
 				// Calc distance from plane
 				VertDistance[BaseVertIndex] = SlicePlane.PlaneDot(Position);

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshRenderable.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshRenderable.h
@@ -64,13 +64,13 @@ public:
 		return *((FVector3f*)&Data[Index * sizeof(FVector3f)]);
 	}
 
-	FBox3f GetBounds() const
+	FBox GetBounds() const
 	{
-		FBox3f NewBox(ForceInit);
+		FBox NewBox(ForceInit);
 		int32 Count = Num();
 		for (int32 Index = 0; Index < Count; Index++)
 		{
-			NewBox += GetPosition(Index);
+			NewBox += FVector(GetPosition(Index));
 		}
 		return NewBox;
 	}

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshRenderable.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshRenderable.h
@@ -64,9 +64,9 @@ public:
 		return *((FVector3f*)&Data[Index * sizeof(FVector3f)]);
 	}
 
-	FBox GetBounds() const
+	FBox3f GetBounds() const
 	{
-		FBox NewBox(ForceInit);
+		FBox3f NewBox(ForceInit);
 		int32 Count = Num();
 		for (int32 Index = 0; Index < Count; Index++)
 		{
@@ -181,12 +181,12 @@ public:
 		if (bIsHighPrecision)
 		{
 			*((FPackedRGBA16N*)&Data[Index]) = FPackedRGBA16N(InTangentX);
-			*((FPackedRGBA16N*)&Data[Index + sizeof(FPackedRGBA16N)]) = FPackedRGBA16N(FVector4f(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
+			*((FPackedRGBA16N*)&Data[Index + sizeof(FPackedRGBA16N)]) = FPackedRGBA16N(FVector4f(InTangentZ, GetBasisDeterminantSign(FVector(InTangentX), FVector(InTangentY), FVector(InTangentZ))));
 		}
 		else
 		{
 			*((FPackedNormal*)&Data[Index]) = FPackedNormal(InTangentX);
-			*((FPackedNormal*)&Data[Index + sizeof(FPackedNormal)]) = FPackedNormal(FVector4f(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
+			*((FPackedNormal*)&Data[Index + sizeof(FPackedNormal)]) = FPackedNormal(FVector4f(InTangentZ, GetBasisDeterminantSign(FVector(InTangentX), FVector(InTangentY), FVector(InTangentZ))));
 		}
 		return Index / Stride;
 	}
@@ -260,12 +260,12 @@ public:
 		if (bIsHighPrecision)
 		{
 			*((FPackedRGBA16N*)&Data[EntryIndex * sizeof(FPackedRGBA16N)]) = FPackedRGBA16N(InTangentX);
-			*((FPackedRGBA16N*)&Data[(EntryIndex + 1) * sizeof(FPackedRGBA16N)]) = FPackedRGBA16N(FVector4f(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
+			*((FPackedRGBA16N*)&Data[(EntryIndex + 1) * sizeof(FPackedRGBA16N)]) = FPackedRGBA16N(FVector4f(InTangentZ, GetBasisDeterminantSign(FVector(InTangentX), FVector(InTangentY), FVector(InTangentZ))));
 		}
 		else
 		{
 			*((FPackedNormal*)&Data[EntryIndex * sizeof(FPackedNormal)]) = FPackedNormal(InTangentX);
-			*((FPackedNormal*)&Data[(EntryIndex + 1) * sizeof(FPackedNormal)]) = FPackedNormal(FVector4f(InTangentZ, GetBasisDeterminantSign(InTangentX, InTangentY, InTangentZ)));
+			*((FPackedNormal*)&Data[(EntryIndex + 1) * sizeof(FPackedNormal)]) = FPackedNormal(FVector4f(InTangentZ, GetBasisDeterminantSign(FVector(InTangentX), FVector(InTangentY), FVector(InTangentZ))));
 		}
 	}
 


### PR DESCRIPTION
In UE5 Preview 2 it was possible to say `FVector3f a = FVector(0)`, I.E. there was an implicit conversion between the two.
This was seemingly removed in UE 5.0.0 release, so explicit conversions are required.
I've only changed `variable` to `FVector(variable)` (and vice versa) all places where this is occurring. There may be places where this could be further optimized by changing the original type from/to FVector<->FVector3f (and FBox, FPlane, etc), but this PR only adds the removed conversion to work exactly like it did for Preview 2.