### PR TITLE
added IsUpdatingMesh

### DIFF
--- a/Source/RuntimeMeshComponent/Public/RuntimeMesh.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMesh.h
@@ -51,6 +51,8 @@ private:
 	// State tracking for async thread synchronization
 	FThreadSafeBool bQueuedForMeshUpdate;
 
+	// Number of mesh update tasks which are currently running. Used to determine if mesh is being updated. Always 0 if MeshProviderPtr is not thread safe.
+	FThreadSafeCounter NumMeshUpdateTasks;
 
 	// Whether this mesh needs to be initialized by the tick object. 
 	// This is to get away from postload so BP calls in the 
@@ -142,6 +144,8 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
 	UBodySetup* ForceCollisionUpdate(bool bForceCookNow = true);
 
+	UFUNCTION(BlueprintPure, Category = "Components|RuntimeMesh")
+	bool IsUpdatingMesh() const { return NumMeshUpdateTasks.GetValue() != 0; }
 
 	//	Begin IRuntimeMeshProviderTargetInterface interface
 	virtual FRuntimeMeshWeakRef GetMeshReference() override { return GCAnchor.GetReference(); }

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
@@ -108,7 +108,12 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshComponent")
 	FRuntimeMeshCollisionHitInfo GetHitSource(int32 FaceIndex) const;
 
-
+	UFUNCTION(BlueprintPure, Category = "Components|RuntimeMeshComponent")
+	bool IsUpdatingMesh() const 
+	{ 
+		URuntimeMesh* Mesh = GetRuntimeMesh();
+		return Mesh ? Mesh->IsUpdatingMesh() : false;
+	}
 
 private:
 


### PR DESCRIPTION
Added IsUpdatingMesh function to URuntimeMeshComponent and URuntimeMesh, which returns true if mesh is being updated in multithread.
bQueuedForMeshUpdate is set to false before HandleUpdate in FRuntimeMeshUpdateTask. This makes it possible to run 2 or more tasks at once. This is why a thread safe counter, not bool, is used to check if mesh is being updated.