### PR TITLE
added a delegete for when mesh update is done

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -698,6 +698,14 @@ void URuntimeMesh::RecreateAllComponentSceneProxies(bool bEndOfMeshCalculation /
 			
 			if (bEndOfMeshCalculation)
 			{
+				{
+					FWriteScopeLock Lock(Mesh->MeshProviderLock);
+					if (Mesh->MeshProviderPtr)
+					{
+						Mesh->MeshProviderPtr->MeshUpdateCompleted();
+					}
+				}
+
 				// Call user event to notify of the end of mesh data calculation
 				if (Mesh->MeshDataCalculationCompleted.IsBound())
 				{

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshProvider.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshProvider.cpp
@@ -366,6 +366,15 @@ void URuntimeMeshProviderPassthrough::CollisionUpdateCompleted()
 	}
 }
 
+void URuntimeMeshProviderPassthrough::MeshUpdateCompleted()
+{
+	FReadScopeLock Lock(ChildLock);
+	if (ChildProvider)
+	{
+		ChildProvider->MeshUpdateCompleted();
+	}
+}
+
 
 bool URuntimeMeshProviderPassthrough::IsThreadSafe()
 {

--- a/Source/RuntimeMeshComponent/Public/RuntimeMesh.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMesh.h
@@ -33,6 +33,10 @@ enum class ESectionUpdateType : uint8
 
 ENUM_CLASS_FLAGS(ESectionUpdateType);
 
+/**
+*	Delegate for when the mesh update is done.
+*/
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FRuntimeMeshDataCalculationCompletedDelegate);
 
 /**
 *	Delegate for when the collision was updated.
@@ -128,6 +132,9 @@ public:
 	FRuntimeMeshCollisionHitInfo GetHitSource(int32 FaceIndex) const;
 
 public:
+	// Event called when the mesh data has finished updated. This does NOT guarantee the end of rendering update, but just notifies the work updating mesh in RMC's thread (or game thread depending on your RMP's thread safety) is done. Works for both synchronous and async mesh update.
+	UPROPERTY(BlueprintAssignable, Category = "Components|RuntimeMesh")
+	FRuntimeMeshDataCalculationCompletedDelegate MeshDataCalculationCompleted;
 
 	/** Event called when the collision has finished updated, this works both with standard following frame synchronous updates, as well as async updates */
 	UPROPERTY(BlueprintAssignable, Category = "Components|RuntimeMesh")
@@ -200,7 +207,7 @@ private:
 	void QueueForCollisionUpdate();
 
 	void UpdateAllComponentBounds();
-	void RecreateAllComponentSceneProxies();
+	void RecreateAllComponentSceneProxies(bool bEndOfMeshCalculation = false);
 
 
 	void HandleUpdate();

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshProvider.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshProvider.h
@@ -56,9 +56,13 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "RuntimeMeshProvider|ConfigureLODs")
 	virtual bool GetCollisionMesh(FRuntimeMeshCollisionData& CollisionData) { return false; }
 
+	// Called in game thread when collision update is done.
 	UFUNCTION(BlueprintCallable, Category = "RuntimeMeshProvider|ConfigureLODs")
 	virtual void CollisionUpdateCompleted() { }
 
+	// Called in game thread when mesh calculation is done.
+	UFUNCTION(BlueprintCallable, Category = "RuntimeMeshProvider|ConfigureLODs")
+	virtual void MeshUpdateCompleted() { }
 
 	UFUNCTION(BlueprintCallable, Category = "RuntimeMeshProvider|ConfigureLODs")
 	virtual bool IsThreadSafe() { return false; }
@@ -139,7 +143,7 @@ public:
 	virtual bool HasCollisionMesh() override;
 	virtual bool GetCollisionMesh(FRuntimeMeshCollisionData& CollisionData) override;
 	virtual void CollisionUpdateCompleted() override;
-
+	virtual void MeshUpdateCompleted() override;
 
 	virtual bool IsThreadSafe() override;
 


### PR DESCRIPTION
Added a delegate to URuntimeMesh class, which is invoked after mesh calculation in RMC's thread or game thread depending on your RMP's IsThreadSafe. This does NOT guarantee the end of rendering update.
This delegate is invoked on game thread and works for both synchronous and asynchronous mesh update.

This delegate is useful if you have no collision but want to do something after mesh update, or if you want to know the end of your mesh calculation such as GetSectionMeshForLOD/GetAllSectionsMeshForLOD.

There already is CollisionUpdated delegate for collision update, but it is not that convenient because it is not called if HasCollisionMesh returns false.