### PR TITLE
Added Logs when a MeshProvider supplies invalid data

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -890,7 +890,7 @@ void URuntimeMesh::HandleSingleSectionUpdate(const FRuntimeMeshProxyPtr& RenderP
 		Properties.bWants32BitIndices);
 	bool bResult = MeshProviderPtr->GetSectionMeshForLOD(LODId, SectionId, MeshData);
 	
-	if (bResult && MeshData.HasValidMeshData())
+	if (bResult && MeshData.HasValidMeshData(true))
 	{
 		// Update section
 		TSharedPtr<FRuntimeMeshSectionUpdateData> UpdateData = MakeShared<FRuntimeMeshSectionUpdateData>(MoveTemp(MeshData));
@@ -907,6 +907,8 @@ void URuntimeMesh::HandleSingleSectionUpdate(const FRuntimeMeshProxyPtr& RenderP
 	}
 	else
 	{
+		UE_LOG(RuntimeMeshLog, Warning, TEXT("Could not Handle Section Update, Invalid Data: LOD:%d Section:%d"), LODId, SectionId);
+		
 		// Clear section
 		RenderProxyRef->ClearSection_GameThread(LODId, SectionId);
 		bRequiresProxyRecreate |= Properties.UpdateFrequency == ERuntimeMeshUpdateFrequency::Infrequent;


### PR DESCRIPTION
When you implement a custom `URuntimeMeshProvider` and you (accidentally or not) supply an invalid `FRuntimeMeshRenderableMeshData` in your overridden `GetSectionMeshForLOD`, RMC will just silently ignore this section and not render it at all. This might make it very difficult to find the error.

I opted to enable the verbosity of `FRuntimeMeshRenderableMeshData::HasValidMeshData()` and additionally add a Warning when the function returns false.