### PR TITLE
Fix UE 5.1 crash on startup.

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -887,7 +887,7 @@ void URuntimeMesh::HandleSingleSectionUpdate(const FRuntimeMeshProxyPtr& RenderP
 		TSharedPtr<FRuntimeMeshSectionUpdateData> UpdateData = MakeShared<FRuntimeMeshSectionUpdateData>(MoveTemp(MeshData));
 
 		// Push the data to the gpu from this thread if we're not on the game thread and the current RHI supports async
-		if (GRHISupportsAsyncTextureCreation && GIsThreadedRendering && !IsInGameThread())
+		if (GRHISupportsAsyncTextureCreation && GIsThreadedRendering && IsInRenderingThread() && !IsInGameThread())
 		{
 			UpdateData->CreateRHIBuffers<false>(Properties.UpdateFrequency == ERuntimeMeshUpdateFrequency::Frequent);
 		}

--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -887,7 +887,7 @@ void URuntimeMesh::HandleSingleSectionUpdate(const FRuntimeMeshProxyPtr& RenderP
 		TSharedPtr<FRuntimeMeshSectionUpdateData> UpdateData = MakeShared<FRuntimeMeshSectionUpdateData>(MoveTemp(MeshData));
 
 		// Push the data to the gpu from this thread if we're not on the game thread and the current RHI supports async
-		if (GRHISupportsAsyncTextureCreation && GIsThreadedRendering && IsInRenderingThread() && !IsInGameThread())
+		if (GRHISupportsAsyncTextureCreation && GIsThreadedRendering && IsInRenderingThread())
 		{
 			UpdateData->CreateRHIBuffers<false>(Properties.UpdateFrequency == ERuntimeMeshUpdateFrequency::Frequent);
 		}


### PR DESCRIPTION
Fixes a crash on startup triggered in D3D12Buffer.cpp where a check fails on being in a rendering thread.
